### PR TITLE
PagerDuty improvements

### DIFF
--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -28,7 +28,10 @@ def main(args, in_stream):
     lambda_region = os.environ.get('LAMBDA_REGION', 'us-west-2')
     lambda_up = LambdaUploader(clients, lambda_region, lambda_bucket)
     pagerduty_default = os.environ.get('WEBHOOKS_PAGERDUTY')
-    endpoint_factory = AlarmEndpointFactory.get(pagerduty_default, lambda_up)
+    pagerduty_api_key = os.environ.get('PAGERDUTY_API_KEY')
+    endpoint_factory = AlarmEndpointFactory.get(pagerduty_default,
+                                                pagerduty_api_key,
+                                                lambda_up)
     trigger_factory = TriggerFactory()
 
     # Templates:

--- a/src/spacel/provision/alarm/endpoint/factory.py
+++ b/src/spacel/provision/alarm/endpoint/factory.py
@@ -40,10 +40,11 @@ class AlarmEndpointFactory(object):
         return endpoint_resources
 
     @staticmethod
-    def get(pagerduty_default, lambda_uploader):
+    def get(pagerduty_default, pagerduty_api_key, lambda_uploader):
         return AlarmEndpointFactory({
             'email': EmailEndpoints(),
-            'pagerduty': PagerDutyEndpoints(pagerduty_default),
+            'pagerduty': PagerDutyEndpoints(pagerduty_default,
+                                            pagerduty_api_key),
             'slack': SlackEndpoints(lambda_uploader),
             'scale': ScaleEndpoints(),
             'scaledown': ScaleEndpoints(direction=-1),

--- a/src/spacel/provision/alarm/endpoint/pagerduty.py
+++ b/src/spacel/provision/alarm/endpoint/pagerduty.py
@@ -1,8 +1,21 @@
+import json
 import logging
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
 from spacel.provision import clean_name
 from spacel.provision.alarm.actions import ACTIONS_NONE, ACTIONS_OK_ALARM
 
 logger = logging.getLogger('spacel.provision.alarm.endpoint.pagerduty')
+
+PD_API_BASE = 'https://api.pagerduty.com/'
+PD_EVENTS_BASE = 'https://events.pagerduty.com/adapter/cloudwatch_sns/v1/'
+APPLICATION_JSON = 'application/json; charset=utf-8'
+
+# https://support.pagerduty.com/hc/en-us/articles/219898067-Create-a-Vendor-Specific-Service-with-the-API
+VENDOR_CLOUDWATCH = 'PZQ6AUS'
+
+INTEGRATION_TYPE = 'event_transformer_api_inbound_integration_reference'
 
 
 class PagerDutyEndpoints(object):
@@ -11,11 +24,18 @@ class PagerDutyEndpoints(object):
     PagerDuty provides an SNS compatible WebHook.
     """
 
-    def __init__(self, default_url):
+    def __init__(self, default_url, pd_api_key):
         self._default_url = default_url
+        self._pd_headers = {}
+        if pd_api_key:
+            self._pd_headers['Authorization'] = 'Token token=%s' % pd_api_key
+
+    @staticmethod
+    def resource_name(name):
+        return 'EndpointPagerDuty%sTopic' % clean_name(name)
 
     def add_endpoints(self, template, name, params):
-        url = self._get_url(params)
+        url = self._get_url(template, params)
         if not url:
             logger.warn('PagerDuty endpoint %s is missing "url".', name)
             return ACTIONS_NONE
@@ -29,16 +49,136 @@ class PagerDutyEndpoints(object):
                 'DisplayName': {'Fn::Join': [
                     ' ', [
                         {'Ref': 'AWS::StackName'},
-                        'CloudWatchEmailAlarms']
+                        'CloudWatchPagerDutyAlarms']
                 ]}
             }
         }
         return ACTIONS_OK_ALARM
 
-    def _get_url(self, params):
-        # TODO: PagerDuty smarts: if URL isn't found, lookup/register using API
-        return params.get('url', self._default_url)
+    def _get_url(self, template, params):
+        parameters = template['Parameters']
+        service = parameters['Service']['Default']
+        orbit = parameters['Orbit']['Default']
+        pd_service_name = '%s (%s)' % (service, orbit)
 
-    @staticmethod
-    def resource_name(name):
-        return 'EndpointPagerDuty%sTopic' % clean_name(name)
+        url = params.get('url')
+        if url:
+            return url
+
+        # Without PagerDuty API key we can't continue:
+        if not self._pd_headers:
+            return self._default_url
+
+        # Service can be specified by id:
+        service_id = params.get('service')
+        if service_id:
+            integration_key = self._integration_key(service_id)
+            if integration_key:
+                return '%s/%s' % (PD_EVENTS_BASE, integration_key)
+
+        # Escalation policy can be specified by id:
+        escalation = params.get('escalation_policy')
+        if escalation:
+            url = '/escalation_policies/%s?include[]=service' % escalation
+            policy = self._pd_api(url)
+            if not policy:
+                logger.warn('Escalation policy %s not found.', escalation)
+            else:
+                policy = policy['escalation_policy']
+                logger.debug('Using escalation policy "%s" (%s).',
+                             policy['summary'],
+                             escalation)
+
+                service_id = self._service_id(policy, escalation,
+                                              pd_service_name)
+                if service_id:
+                    integration_key = self._integration_key(service_id)
+                    if integration_key:
+                        return '%s/%s' % (PD_EVENTS_BASE, integration_key)
+
+        return self._default_url
+
+    def _integration_key(self, service_id):
+        # Fetch service details:
+        service = self._pd_api('/services/%s' % service_id)
+        if not service:
+            logger.warn('Invalid service "%s".', service_id)
+            return None
+        service = service['service']
+
+        # Check for existing integration:
+        for integration in service['integrations']:
+            if integration['type'] == INTEGRATION_TYPE:
+                integration_id = integration['id']
+                logger.debug('Found existing integration "%s".', integration_id)
+
+                integration_url = ('/services/%s/integrations/%s'
+                                   % (service_id, integration_id))
+                integration = self._pd_api(integration_url)
+                return integration['integration']['integration_key']
+
+        logger.debug('Integration not found, creating...')
+
+        integration_params = {
+            'type': INTEGRATION_TYPE,
+            'vendor': {
+                'type': 'vendor_reference',
+                'id': VENDOR_CLOUDWATCH
+            }
+        }
+        new_integration = self._pd_api('/services/%s/integrations' % service_id,
+                                       method='POST',
+                                       data={
+                                           'integration': integration_params
+                                       })
+        new_integration = new_integration['integration']
+        return new_integration['integration_key']
+
+    def _service_id(self, policy, escalation, service_name):
+        # Check for existing service:
+        for service in policy.get('services', ()):
+            if service['summary'] == service_name:
+                service_url = service['self']
+                service_id = service_url.split('/')[-1]
+                logger.debug('Found existing service "%s" (%s).', service_name,
+                             service_id)
+                return service_id
+
+        logger.debug('Service not found, creating...')
+        service_params = {
+            'name': service_name,
+            'type': 'service',
+            'escalation_policy': {
+                'id': escalation,
+                'type': 'escalation_policy_reference'
+            }}
+        new_service = self._pd_api('/services', method='POST',
+                                   data={'service': service_params})
+
+        if new_service:
+            service_id = new_service['service']['id']
+            logger.debug('Created service "%s" (%s).', service_name, service_id)
+            return service_id
+        return None
+
+    def _pd_api(self, url, data=None, method='GET'):
+        url = '%s/%s' % (PD_API_BASE, url)
+        request_args = {
+            'method': method,
+            'headers': dict(self._pd_headers)
+        }
+        if data is not None:
+            request_args['data'] = json.dumps(data).encode('utf-8')
+            request_args['headers']['Content-Type'] = APPLICATION_JSON
+
+        request = Request(url, **request_args)
+        try:
+            response = urlopen(request)
+            return json.loads(response.read().decode('utf-8'))
+        except HTTPError as e:
+            response = e.read().decode('utf-8')
+            logger.warn("API error: %s", response)
+            if method == 'GET' and e.code == 404:
+                return None
+            else:
+                raise e

--- a/src/spacel/provision/alarm/endpoint/slack.py
+++ b/src/spacel/provision/alarm/endpoint/slack.py
@@ -112,7 +112,7 @@ class SlackEndpoints(object):
                 'DisplayName': {'Fn::Join': [
                     ' ', [
                         {'Ref': 'AWS::StackName'},
-                        'CloudWatchEmailAlarms']
+                        'CloudWatchSlackAlarms']
                 ]}
             }
         }

--- a/src/test/provision/alarm/endpoint/test_factory.py
+++ b/src/test/provision/alarm/endpoint/test_factory.py
@@ -49,5 +49,5 @@ class TestAlarmEndpointFactory(unittest.TestCase):
                                                                params)
 
     def test_get(self):
-        endpoint_factory = AlarmEndpointFactory.get(None, None)
+        endpoint_factory = AlarmEndpointFactory.get(None, None, None)
         self.assertIsInstance(endpoint_factory, AlarmEndpointFactory)

--- a/src/test/provision/alarm/endpoint/test_pagerduty.py
+++ b/src/test/provision/alarm/endpoint/test_pagerduty.py
@@ -1,19 +1,41 @@
-from spacel.provision.alarm.endpoint.pagerduty import PagerDutyEndpoints
+from io import BytesIO
+from mock import MagicMock, patch, ANY
+from urllib.error import HTTPError
+
+from spacel.provision.alarm.endpoint.pagerduty import (PagerDutyEndpoints,
+                                                       INTEGRATION_TYPE)
 from test.provision.alarm.endpoint import RESOURCE_NAME, BaseEndpointTest
 
 DEFAULT_URL = 'https://api.pagerduty.com/hook'
+OTHER_URL = 'https://test.com'
+
+SERVICE_ID = '123456'
+SERVICE_NAME = 'test-service'
+API_KEY = 'api-key'
+
+INTEGRATION_KEY = '123456789012345667890'
+INTEGRATION_KEY_URL = 'https://events.pagerduty.com/adapter' \
+                      '/cloudwatch_sns/v1//123456789012345667890'
 
 
 class TestPagerDutyEndpoints(BaseEndpointTest):
     def setUp(self):
         super(TestPagerDutyEndpoints, self).setUp()
-        self.endpoint = PagerDutyEndpoints(DEFAULT_URL)
+        self.endpoint = PagerDutyEndpoints(DEFAULT_URL, API_KEY)
+        self.template['Parameters'] = {
+            'Orbit': {
+                'Default': 'test'
+            },
+            'Service': {
+                'Default': 'test-app'
+            }
+        }
 
     def topic_resource(self):
         return 'EndpointPagerDutyTestResourceTopic'
 
     def test_add_endpoints_invalid(self):
-        self.endpoint = PagerDutyEndpoints(None)
+        self.endpoint = PagerDutyEndpoints(None, None)
         actions = self.endpoint.add_endpoints(self.template, RESOURCE_NAME, {})
         self.assertEquals(0, len(actions))
         self.assertEquals(0, len(self.resources))
@@ -24,3 +46,178 @@ class TestPagerDutyEndpoints(BaseEndpointTest):
         self.assertEquals(1, len(self.resources))
         self.assertIn(self.topic_resource(), self.resources)
         self.assertEquals(1, len(self.subscriptions()))
+
+    def test_get_url_simple(self):
+        url = self.endpoint._get_url(self.template, {
+            'url': OTHER_URL
+        })
+        self.assertEquals(OTHER_URL, url)
+
+    def test_get_url_no_headers(self):
+        self.endpoint._integration_key = MagicMock()
+        self.endpoint._service_id = MagicMock()
+        self.endpoint._pd_headers = {}
+
+        url = self.endpoint._get_url(self.template, {})
+        self.assertEquals(DEFAULT_URL, url)
+
+        # No API keys? No API calls:
+        self.endpoint._integration_key.assert_not_called()
+        self.endpoint._service_id.assert_not_called()
+
+    def test_get_url_service_id(self):
+        self.endpoint._integration_key = MagicMock(return_value=INTEGRATION_KEY)
+        self.endpoint._service_id = MagicMock()
+
+        url = self.endpoint._get_url(self.template, {
+            'service': SERVICE_ID
+        })
+
+        self.assertEquals(INTEGRATION_KEY_URL, url)
+
+        self.endpoint._integration_key.assert_called_with(SERVICE_ID)
+        self.endpoint._service_id.assert_not_called()
+
+    def test_get_url_escalation_success(self):
+        # Lookup by escalation policy finds service, which has integration key:
+        self.endpoint._integration_key = MagicMock(return_value=INTEGRATION_KEY)
+        self.endpoint._service_id = MagicMock(return_value=SERVICE_ID)
+        self.endpoint._pd_api = MagicMock(return_value={
+            'escalation_policy': {
+                'summary': 'Test Policy'
+            }
+        })
+
+        url = self.endpoint._get_url(self.template, {
+            'escalation_policy': '654321'
+        })
+
+        self.assertEquals(INTEGRATION_KEY_URL, url)
+
+    def test_get_url_escalation_missing(self):
+        # Lookup by escalation policy, policy not found:
+        self.endpoint._integration_key = MagicMock(return_value=INTEGRATION_KEY)
+        self.endpoint._service_id = MagicMock(return_value=SERVICE_ID)
+        self.endpoint._pd_api = MagicMock(return_value=None)
+
+        url = self.endpoint._get_url(self.template, {
+            'escalation_policy': '654321'
+        })
+
+        self.assertEquals(DEFAULT_URL, url)
+
+    def test_integration_key_missing(self):
+        """Look up integration key, service not found."""
+        self.endpoint._pd_api = MagicMock(return_value=None)
+
+        integration_key = self.endpoint._integration_key(SERVICE_ID)
+        self.assertIsNone(integration_key)
+
+    def test_integration_key_existing(self):
+        """Look up integration key, discover existing integration."""
+        self.endpoint._pd_api = MagicMock()
+        self.endpoint._pd_api.side_effect = [
+            {
+                'service': {
+                    'integrations': [{
+                        'id': '123456',
+                        'type': INTEGRATION_TYPE
+                    }]
+                }
+            },
+            {
+                'integration': {
+                    'id': '123456',
+                    'integration_key': INTEGRATION_KEY
+                }
+            }
+        ]
+
+        integration_key = self.endpoint._integration_key(SERVICE_ID)
+        self.assertEquals(INTEGRATION_KEY, integration_key)
+
+    def test_integration_key_create(self):
+        """Look up integration key, create new integration."""
+        self.endpoint._pd_api = MagicMock()
+        self.endpoint._pd_api.side_effect = [
+            {
+                'service': {
+                    'integrations': []
+                }
+            },
+            {
+                'integration': {
+                    'id': '123456',
+                    'integration_key': INTEGRATION_KEY
+                }
+            }
+        ]
+
+        integration_key = self.endpoint._integration_key(SERVICE_ID)
+        self.assertEquals(INTEGRATION_KEY, integration_key)
+
+    def test_service_id_existing(self):
+        """Look up service id, discover existing."""
+        service_id = self.endpoint._service_id({
+            'services': [{
+                'summary': SERVICE_NAME,
+                'self': 'http://test/' + SERVICE_ID}
+            ]},
+            '', SERVICE_NAME)
+        self.assertEquals(SERVICE_ID, service_id)
+
+    def test_service_id_create(self):
+        """Look up service id, create."""
+        self.endpoint._pd_api = MagicMock(return_value={
+            'service': {
+                'id': SERVICE_ID
+            }
+        })
+        service_id = self.endpoint._service_id({}, '', SERVICE_NAME)
+        self.assertEquals(SERVICE_ID, service_id)
+
+    def test_service_id_create_failed(self):
+        """Look up service id, create."""
+        self.endpoint._pd_api = MagicMock(return_value=None)
+        service_id = self.endpoint._service_id({}, '', SERVICE_NAME)
+        self.assertIsNone(service_id)
+
+    @patch('spacel.provision.alarm.endpoint.pagerduty.urlopen')
+    def test_pd_api_missing(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError('/', 404, 'Not Found', None,
+                                             BytesIO(b'{}'))
+
+        response = self.endpoint._pd_api('/test')
+
+        self.assertIsNone(response)
+
+    @patch('spacel.provision.alarm.endpoint.pagerduty.urlopen')
+    def test_pd_api_exception(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError('/', 500, 'Kaboom', None,
+                                             BytesIO(b'{}'))
+
+        self.assertRaises(HTTPError, self.endpoint._pd_api, '/test')
+
+    @patch('spacel.provision.alarm.endpoint.pagerduty.urlopen')
+    def test_pd_api_post_data(self, mock_urlopen):
+        self._mock_response(mock_urlopen)
+
+        response = self.endpoint._pd_api('/test', data={}, method='POST')
+
+        mock_urlopen.assert_called_with(ANY)
+        self.assertEquals({'foo': 'bar'}, response)
+
+    @patch('spacel.provision.alarm.endpoint.pagerduty.urlopen')
+    def test_pd_api(self, mock_urlopen):
+        self._mock_response(mock_urlopen)
+
+        response = self.endpoint._pd_api('/test')
+
+        mock_urlopen.assert_called_with(ANY)
+        self.assertEquals({'foo': 'bar'}, response)
+
+    @staticmethod
+    def _mock_response(mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = '{"foo":"bar"}'.encode('utf-8')
+        mock_urlopen.return_value = mock_response


### PR DESCRIPTION
If you built a service with CloudWatch integration, use `url`. This was
previously the only supported option.

If you built a service w/o CloudWatch integration, use `service`:
CloudWatch integration will be discovered, created if necessary.

If you built an escalation policy, use `escalation_policy`: an
appropriately named service with CloudWatch integration will be
discovered, created if necessary.

`escalation_policy` is targetting as the most sane default: having clean
Service names in PagerDuty make it easier to grok an incoming page at
2am.