### PR TITLE
WEBOPS-898: fully custom CW triggers

### DIFF
--- a/sample/app/http-env-echo-alarms.json
+++ b/sample/app/http-env-echo-alarms.json
@@ -36,14 +36,36 @@
       "HighCpu": {
         "metric": "EC2/CPUUtilization",
         "threshold": ">85",
-        "duration": "3x60",
-        "endpoints": ["emailpete", "more_instances"]
+        "period": "3x60",
+        "endpoints": ["emailpete"]
       },
       "LowCpu": {
         "metric": "EC2/CPUUtilization",
         "threshold": "<15",
-        "duration": "3x60",
-        "endpoints": ["emailpete", "less_instances"]
+        "period": "3x60",
+        "endpoints": ["emailpete"]
+      },
+      "QueueDeep": {
+        "namespace": "AWS/SQS",
+        "metric": "ApproximateNumberOfMessagesVisible",
+        "threshold": ">=5",
+        "period": "3x60",
+        "statistic": "Average",
+        "dimensions": {
+          "QueueName": "pwagner-test"
+        },
+        "endpoints": ["more_instances"]
+      },
+      "QueueShallow": {
+        "namespace": "AWS/SQS",
+        "metric": "ApproximateNumberOfMessagesVisible",
+        "threshold": "<5",
+        "period": "3x60",
+        "statistic": "Average",
+        "dimensions": {
+          "QueueName": "pwagner-test"
+        },
+        "endpoints": ["less_instances"]
       }
     }
   }

--- a/src/spacel/provision/alarm/trigger/metrics.py
+++ b/src/spacel/provision/alarm/trigger/metrics.py
@@ -17,10 +17,9 @@ class MetricDefinitions(object):
         http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html
         :return:
         """
-        asg_dimensions = [{
-            'Name': 'AutoScalingGroupName',
-            'Value': {'Ref': 'Asg'}
-        }]
+        asg_dimensions = {
+            'AutoScalingGroupName': {'Ref': 'Asg'}
+        }
         self._metric([
             'EC2/CPUCreditUsage'
         ], {
@@ -140,16 +139,15 @@ class MetricDefinitions(object):
         http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html
         :return:
         """
-        elb_dimensions = [{
-            'Name': 'LoadBalancerName',
-            'Value': {
+        elb_dimensions = {
+            'LoadBalancerName': {
                 'Fn::If': [
                     'ElbPublic',
                     {'Ref': 'PublicElb'},
                     {'Ref': 'PrivateElb'}
                 ]
             }
-        }]
+        }
         self._metric([
             'ELB/UnHealthyHostCount',
             'unhealthyhosts',
@@ -269,16 +267,11 @@ class MetricDefinitions(object):
             'statistic': 'Average',
             'threshold': '>85',
             'period': '10x60',
-            'dimensions': [{
-                'Name': 'AutoScalingGroupName',
-                'Value': {'Ref': 'Asg'}
-            }, {
-                'Name': 'Filesystem',
-                'Value': '-'
-            }, {
-                'Name': 'MountPath',
-                'Value': '/'
-            }]
+            'dimensions': {
+                'AutoScalingGroupName': {'Ref': 'Asg'},
+                'Filesystem': '-',
+                'MountPath': '/'
+            }
         })
         self._metric([
             'System/MemoryUtilization',
@@ -290,10 +283,9 @@ class MetricDefinitions(object):
             'statistic': 'Average',
             'threshold': '>85',
             'period': '10x60',
-            'dimensions': [{
-                'Name': 'AutoScalingGroupName',
-                'Value': {'Ref': 'Asg'}
-            }]
+            'dimensions': {
+                'AutoScalingGroupName': {'Ref': 'Asg'}
+            }
         })
 
     def _metric(self, aliases, data):

--- a/src/test/provision/alarm/trigger/test_factory.py
+++ b/src/test/provision/alarm/trigger/test_factory.py
@@ -54,6 +54,24 @@ class TestTriggerFactory(unittest.TestCase):
         self._add_triggers()
         self.assertEquals(0, len(self.resources))
 
+    def test_add_triggers_full_custom_invalid(self):
+        self.params['namespace'] = 'AWS/SQS'
+        self.params['metric'] = 'ApproximateNumberOfMessagesVisible'
+        self._add_triggers()
+        self.assertEquals(0, len(self.resources))
+
+    def test_add_triggers_full_custom(self):
+        self.params['namespace'] = 'AWS/SQS'
+        self.params['metric'] = 'ApproximateNumberOfMessagesVisible'
+        self.params['dimensions'] = {
+            'QueueName': 'test-queue'
+        }
+        self.params['statistic'] = 'Average'
+        self._add_triggers()
+        self.assertEquals(1, len(self.resources))
+        alarm_params = self.resources['Alarmtest']['Properties']
+        self.assertIn('Dimensions', alarm_params)
+
     def test_add_triggers(self):
         self._add_triggers()
         self.assertEquals(1, len(self.resources))


### PR DESCRIPTION
Instead of automatically scoping to the ASG/ELB, if you know the
`Namespace`, `MetricName`, `Dimensions` you can tie into anything you
fancy.

Update the alarm sample application to trigger scaling based on SQS
queue depth.

Refactor `dimensions` logic to be more user-friendly (since they can be
defined in parameters now).