### PR TITLE
Hotfix: explicit tests for string scaling sets

### DIFF
--- a/src/spacel/provision/alarm/endpoint/scale.py
+++ b/src/spacel/provision/alarm/endpoint/scale.py
@@ -1,4 +1,6 @@
 import logging
+from six import string_types
+
 from spacel.provision import clean_name
 from spacel.provision.alarm.actions import ACTION_ALARM, ACTIONS_NONE
 
@@ -17,7 +19,7 @@ class ScaleEndpoints(object):
         adjustment = params.get('adjustment', 1)
 
         adjustment_type = 'ChangeInCapacity'
-        if isinstance(adjustment, str) and '%' in adjustment:
+        if isinstance(adjustment, string_types) and '%' in adjustment:
             adjustment_type = 'PercentChangeInCapacity'
             adjustment = int(adjustment.replace('%', ''))
 
@@ -42,9 +44,10 @@ class ScaleEndpoints(object):
         return ACTION_ALARM,
 
     def _calculate_adjustment(self, adjustment):
+        adjustment = int(adjustment)
         if self._direction is not None:
             adjustment = abs(adjustment) * self._direction
-        return int(adjustment)
+        return adjustment
 
     @staticmethod
     def resource_name(name):

--- a/src/test/provision/alarm/endpoint/test_scale.py
+++ b/src/test/provision/alarm/endpoint/test_scale.py
@@ -1,3 +1,4 @@
+from six import u
 from spacel.provision.alarm.endpoint.scale import ScaleEndpoints
 from test.provision.alarm.endpoint import RESOURCE_NAME, BaseEndpointTest
 
@@ -32,11 +33,15 @@ class TestScaleEndpoints(BaseEndpointTest):
         self.endpoint = ScaleEndpoints(direction=-1)
         self.assertEquals(-1, self.endpoint._calculate_adjustment(1))
         self.assertEquals(-1, self.endpoint._calculate_adjustment(-1))
+        self.assertEquals(-1, self.endpoint._calculate_adjustment(u('1')))
+        self.assertEquals(-1, self.endpoint._calculate_adjustment('1'))
 
     def test_calculate_adjustment_direction_up(self):
         self.endpoint = ScaleEndpoints(direction=1)
         self.assertEquals(1, self.endpoint._calculate_adjustment(1))
         self.assertEquals(1, self.endpoint._calculate_adjustment(-1))
+        self.assertEquals(1, self.endpoint._calculate_adjustment(u('1')))
+        self.assertEquals(1, self.endpoint._calculate_adjustment('1'))
 
     def test_calculate_adjustment_direction_undefined(self):
         self.assertEquals(1, self.endpoint._calculate_adjustment(1))


### PR DESCRIPTION
Since these are sourced from JSON, this is how they'll usually be input
(percentages especially).

Failing test case on Python2 threw:
`TypeError: bad operand type for abs(): 'unicode'`

Fixing said test case with small refactor: cast earlier.