### PR TITLE
Cache ingress rules

### DIFF
--- a/sample/app/http-env-echo-redis.json
+++ b/sample/app/http-env-echo-redis.json
@@ -19,7 +19,10 @@
   },
   "caches": {
     "some-db": {
-      "replicas": 0
+      "replicas": 0,
+      "clients": [
+        "192.168.0.0/16"
+      ]
     }
   }
 }

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -10,7 +10,8 @@ from spacel.provision import (ChangeSetEstimator, CloudProvisioner,
                               TemplateUploader)
 
 from spacel.provision.template import (AppTemplate, BastionTemplate,
-                                       TablesTemplate, VpcTemplate)
+                                       IngressResourceFactory, TablesTemplate,
+                                       VpcTemplate)
 from spacel.provision.alarm import AlarmFactory
 from spacel.provision.cache import CacheFactory
 
@@ -40,7 +41,8 @@ def main(args, in_stream):
     alarm_factory = AlarmFactory.get(pagerduty_default,
                                      pagerduty_api_key,
                                      lambda_up)
-    cache_factory = CacheFactory()
+    ingress_factory = IngressResourceFactory(clients)
+    cache_factory = CacheFactory(ingress_factory)
 
     # Templates:
     ami_finder = AmiFinder()

--- a/src/spacel/model/orbit.py
+++ b/src/spacel/model/orbit.py
@@ -78,9 +78,11 @@ class Orbit(object):
     def bastion_sg(self, region):
         return self._bastion_sgs.get(region)
 
-    # TODO: why isn't this a tuple like subnets?
     def bastion_eips(self, region):
         return self._bastion_eips.get(region, {})
+
+    def nat_eips(self, region):
+        return self._nat_eips.get(region, {})
 
     def public_instance_subnets(self, region):
         return self._public_instance_subnets.get(region, ())

--- a/src/spacel/provision/alarm/endpoint/pagerduty.py
+++ b/src/spacel/provision/alarm/endpoint/pagerduty.py
@@ -167,7 +167,7 @@ class PagerDutyEndpoints(object):
         request_args = {
             'headers': dict(self._pd_headers)
         }
-        if six.PY3:
+        if six.PY3: # pragma: no cover
             request_args['method'] = method
 
         if data is not None:

--- a/src/spacel/provision/alarm/endpoint/pagerduty.py
+++ b/src/spacel/provision/alarm/endpoint/pagerduty.py
@@ -167,7 +167,7 @@ class PagerDutyEndpoints(object):
         request_args = {
             'headers': dict(self._pd_headers)
         }
-        if six.PY3: # pragma: no cover
+        if six.PY3:  # pragma: no cover
             request_args['method'] = method
 
         if data is not None:

--- a/src/spacel/provision/cache/factory.py
+++ b/src/spacel/provision/cache/factory.py
@@ -10,7 +10,10 @@ REDIS_VERSION = '2.8.24'
 
 
 class CacheFactory(object):
-    def add_caches(self, app, template, caches):
+    def __init__(self, ingress):
+        self._ingress = ingress
+
+    def add_caches(self, app, region, template, caches):
         if not caches:
             logger.debug('No caches specified.')
             return
@@ -90,7 +93,14 @@ class CacheFactory(object):
             user_data.insert(cache_intro, '"%s":"' % name)
             added_caches += 1
 
-            # TODO: ingress rules to share cache with other services
+            clients = params.get('clients', ())
+            ingress_resources = \
+                self._ingress.ingress_resources(app.orbit,
+                                                region,
+                                                6379,
+                                                clients,
+                                                sg_ref=cache_sg_resource)
+            resources.update(ingress_resources)
 
         # If we added any caches, remove trailing comma:
         if added_caches:

--- a/src/spacel/provision/changesets.py
+++ b/src/spacel/provision/changesets.py
@@ -48,6 +48,11 @@ COSTS = {
         'Modify': 2,
         'Remove': 5
     },
+    'AWS::EC2::SecurityGroupIngress': {
+        'Add': 10,
+        'Modify': 10,
+        'Remove': 5
+    },
     'AWS::EC2::SubnetRouteTableAssociation': {
         'Add': 5,
         'Remove': 5

--- a/src/spacel/provision/orbit/space.py
+++ b/src/spacel/provision/orbit/space.py
@@ -117,7 +117,7 @@ class SpaceElevatorOrbitFactory(BaseCloudFormationFactory):
             elif key == 'PrivateCacheSubnetGroup':
                 orbit._private_cache_subnet_groups[region] = value
             elif 'CacheSubnet' in key or 'RdsSubnet' in key:
-                pass
+                continue
             else:
                 logger.warn('Unrecognized output key: %s', key)
 

--- a/src/spacel/provision/template/__init__.py
+++ b/src/spacel/provision/template/__init__.py
@@ -1,4 +1,5 @@
 from .app import AppTemplate
 from .bastion import BastionTemplate
+from .ingress_resource import IngressResourceFactory
 from .tables import TablesTemplate
 from .vpc import VpcTemplate

--- a/src/spacel/provision/template/ingress_resource.py
+++ b/src/spacel/provision/template/ingress_resource.py
@@ -32,7 +32,7 @@ class IngressResourceFactory(object):
 
         # Common properties:
         ingress_properties = {
-            'Protocol': protocol,
+            'IpProtocol': protocol,
             'FromPort': start_port,
             'ToPort': end_port,
             'GroupId': {'Ref': sg_ref}

--- a/src/spacel/provision/template/ingress_resource.py
+++ b/src/spacel/provision/template/ingress_resource.py
@@ -1,0 +1,102 @@
+from botocore.exceptions import ClientError
+import logging
+import re
+
+from spacel.provision import clean_name
+from spacel.model.orbit import PRIVATE_NETWORK
+
+IP_BLOCK = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,3}'
+logger = logging.getLogger('spacel.provision.ingress_resource')
+
+
+class IngressResourceFactory(object):
+    def __init__(self, clients):
+        self._clients = clients
+
+    def ingress_resources(self, orbit, region, start_port, clients,
+                          protocol='TCP', end_port=None, sg_ref='Sg'):
+        """
+        Return ingress resources for access from a list of clients.
+        :param orbit:  Orbit definition.
+        :param region: Region.
+        :param start_port: First port to open
+        :param clients: Client list.
+        :param protocol: Protocol.
+        :param end_port: Last port to open (defaults to start_port if not set).
+        :param sg_ref: Security group name.
+        :return: dict of {resource_name: cloudformation_resource}
+        """
+        # Parameter normalization:
+        if not end_port:
+            end_port = start_port
+
+        # Common properties:
+        ingress_properties = {
+            'Protocol': protocol,
+            'FromPort': start_port,
+            'ToPort': end_port,
+            'GroupId': {'Ref': sg_ref}
+        }
+
+        # Accumulator and helper function to accumulate:
+        ingress_resources = {}
+
+        def ingress_resource(name, **kwargs):
+            kwargs.update(ingress_properties)
+            resource_name = 'Ingress%s%s%s%sto%s' % (sg_ref, clean_name(name),
+                                                     protocol, start_port,
+                                                     end_port)
+
+            ingress_resources[resource_name] = {
+                'Type': 'AWS::EC2::SecurityGroupIngress',
+                'Properties': kwargs
+            }
+
+        # Clients can be...
+        for client in clients:
+            # An IP block:
+            if re.match(IP_BLOCK, client):
+                logger.debug('Adding access from %s.', client)
+                ingress_resource(client, CidrIp=client)
+                continue
+
+            # This orbit region:
+            if client == region:
+                network = '%s.0.0/16' % orbit.get_param(region, PRIVATE_NETWORK)
+                ingress_resource('Orbit%s' % client, CidrIp=network)
+                continue
+
+            # Another orbit region (NAT-ed instances in that region):
+            if client in orbit.regions:
+                logger.debug('Adding access from %s in %s.', orbit.name, client)
+                for nat_index, nat_eip in orbit.nat_eips(client).items():
+                    ingress_resource('Nat%s%s' % (client, nat_index),
+                                     CidrIp='%s/32' % nat_eip)
+                continue
+
+            # An application in the same orbit:
+            sg_id = self.app_sg(orbit, region, client)
+            if sg_id:
+                ingress_resource('App%s' % client, SourceSecurityGroupId=sg_id)
+                continue
+
+            logger.warn('Unknown client: %s', client)
+
+        return ingress_resources
+
+    def app_sg(self, orbit, region, app, sg_ref='Sg'):
+        cloudformation = self._clients.cloudformation(region)
+        stack_name = '%s-%s' % (orbit.name, app)
+        try:
+            resource = cloudformation.describe_stack_resource(
+                StackName=stack_name,
+                LogicalResourceId=sg_ref)
+            return (resource['StackResourceDetail']
+                    ['PhysicalResourceId'])
+        except ClientError as e:
+            e_message = e.response['Error'].get('Message', '')
+            if 'does not exist' in e_message:
+                logger.debug('App %s not found in %s in %s.', app,
+                             orbit.name, region)
+                return None
+            raise e

--- a/src/test/provision/cache/test_factory.py
+++ b/src/test/provision/cache/test_factory.py
@@ -4,8 +4,10 @@ import unittest
 
 from spacel.model import SpaceApp
 from spacel.provision.cache.factory import CacheFactory
+from spacel.provision.template import IngressResourceFactory
 
 CACHE_NAME = 'test-cache'
+REGION = 'us-west-2'
 
 
 class TestCacheFactory(unittest.TestCase):
@@ -38,21 +40,22 @@ class TestCacheFactory(unittest.TestCase):
         self.app.orbit = MagicMock()
         self.app.orbit.name = 'test-orbit'
 
-        self.cache_factory = CacheFactory()
+        self.ingress = MagicMock(spec=IngressResourceFactory)
+        self.cache_factory = CacheFactory(self.ingress)
 
     def test_add_caches_noop(self):
         del self.caches[CACHE_NAME]
-        self.cache_factory.add_caches(self.app, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
         self.assertEquals(1, len(self.resources))
 
     def test_add_caches_invalid_replicas(self):
         self.cache_params['replicas'] = 'meow'
 
-        self.cache_factory.add_caches(self.app, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
         self.assertEquals(1, len(self.resources))
 
     def test_add_caches(self):
-        self.cache_factory.add_caches(self.app, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
         self.assertEquals(3, len(self.resources))
 
         # Resolve {'Ref':}s to a string:

--- a/src/test/provision/orbit/test_space.py
+++ b/src/test/provision/orbit/test_space.py
@@ -136,7 +136,13 @@ class TestSpaceElevatorOrbitFactory(unittest.TestCase):
             'PublicNatSubnet': 'subnet-000121',
             'NatEip': IP_ADDRESS,
             'VpcId': VPC_ID,
+            'PublicRdsSubnetGroup': 'public-rds',
+            'PrivateRdsSubnetGroup': 'private-rds',
+            'PrivateCacheSubnetGroup': 'private-rds',
+            'PrivateCacheSubnet01': 'subnet-666666',
+            'PrivateRdsSubnet01': 'subnet-777777',
             'Unknown': 'AndThatsOk'
+
         }
 
         self.orbit_factory._orbit_from_vpc(self.orbit, REGION,
@@ -151,6 +157,8 @@ class TestSpaceElevatorOrbitFactory(unittest.TestCase):
         self.assertEquals(['subnet-000111'],
                           self.orbit.public_elb_subnets(REGION))
         self.assertEquals(VPC_ID, self.orbit.vpc_id(REGION))
+        self.assertEquals('private-rds',
+                          self.orbit.private_rds_subnet_group(REGION))
 
     def test_orbit_from_bastion(self):
         outputs = {

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -57,7 +57,18 @@ class TestAppTemplate(unittest.TestCase):
 
         app = self.cache.app(self.app, REGION)
 
-        self.assertIn('PrivatePort123TCP', app['Resources'])
+        sg_properties = app['Resources']['PrivatePort123TCP']['Properties']
+        self.assertEquals(123, sg_properties['FromPort'])
+        self.assertEquals(123, sg_properties['ToPort'])
+
+    def test_app_private_ports_split(self):
+        self.app.private_ports = {'123-456': ['TCP']}
+
+        app = self.cache.app(self.app, REGION)
+
+        sg_properties = app['Resources']['PrivatePort123to456TCP']['Properties']
+        self.assertEquals('123', sg_properties['FromPort'])
+        self.assertEquals('456', sg_properties['ToPort'])
 
     def test_app_instance_storage(self):
         self.app.instance_type = 'c1.medium'

--- a/src/test/provision/template/test_ingress_resource.py
+++ b/src/test/provision/template/test_ingress_resource.py
@@ -1,0 +1,93 @@
+from botocore.exceptions import ClientError
+from mock import MagicMock
+import unittest
+import six
+
+from spacel.aws import ClientCache
+from spacel.model import Orbit
+from spacel.provision.template.ingress_resource import IngressResourceFactory
+
+REGION = 'us-west-2'
+OTHER_REGION = 'us-east-1'
+IP_BLOCK = '127.0.0.1/32'
+SECURITY_GROUP = 'sg-123456'
+
+
+class TestIngressResourceFactory(unittest.TestCase):
+    def setUp(self):
+        self.cloudformation = MagicMock()
+        self.clients = MagicMock(speck=ClientCache)
+        self.clients.cloudformation.return_value = self.cloudformation
+        self.orbit = Orbit({
+            'name': 'test-orbit',
+            'regions': [REGION, OTHER_REGION],
+            'defaults': {
+                'private_network': '10.0'
+            }
+        })
+        self.orbit._nat_eips[OTHER_REGION] = {
+            '%02d' % i: '{0}.{0}.{0}.{0}'.format(i)
+            for i in range(1, 4)
+            }
+        self.ingress = IngressResourceFactory(self.clients)
+
+    def test_ingress_resources_ip_block(self):
+        resource = self._only(self._http_ingress(IP_BLOCK))
+        self.assertEquals(IP_BLOCK, resource['Properties']['CidrIp'])
+
+    def test_ingress_resources_region(self):
+        resource = self._only(self._http_ingress(REGION))
+        self.assertEquals('10.0.0.0/16', resource['Properties']['CidrIp'])
+
+    def test_ingress_resources_other_region(self):
+        resources = self._http_ingress(OTHER_REGION)
+        # 1 per Nat EIP:
+        self.assertEquals(3, len(resources))
+        for resource in resources.values():
+            self.assertIn('CidrIp', resource['Properties'])
+
+    def test_ingress_resource_app(self):
+        self.ingress.app_sg = MagicMock(return_value=SECURITY_GROUP)
+        resource = self._only(self._http_ingress('foo'))
+        self.assertNotIn('CidrIp', resource['Properties'])
+        self.assertEquals(SECURITY_GROUP,
+                          resource['Properties']['SourceSecurityGroupId'])
+
+    def test_ingress_resource_app_not_found(self):
+        self.ingress.app_sg = MagicMock(return_value=None)
+        resources = self._http_ingress('foo')
+        self.assertEquals(0, len(resources))
+
+    def test_app_sg(self):
+        self.cloudformation.describe_stack_resource.return_value = {
+            'StackResourceDetail': {
+                'PhysicalResourceId': SECURITY_GROUP
+            }
+        }
+
+        sg = self.ingress.app_sg(self.orbit, REGION, 'test-app')
+        self.assertEquals(SECURITY_GROUP, sg)
+
+    def test_app_sg_not_found(self):
+        self._describe_stack_resource_error('Stack does not exist')
+        sg = self.ingress.app_sg(self.orbit, REGION, 'test-app')
+        self.assertIsNone(sg)
+
+    def test_app_sg_error(self):
+        self._describe_stack_resource_error('Kaboom')
+        self.assertRaises(ClientError, self.ingress.app_sg, self.orbit, REGION,
+                          'test-app')
+
+    def _http_ingress(self, *args):
+        return self.ingress.ingress_resources(self.orbit, REGION, 80, args)
+
+    def _only(self, resources):
+        self.assertEquals(1, len(resources))
+        return six.next(six.itervalues(resources))
+
+    def _describe_stack_resource_error(self, message):
+        self.cloudformation.describe_stack_resource.side_effect = ClientError({
+            'Error': {
+                'Message': message
+            }
+        }, 'CreateSubnet')


### PR DESCRIPTION
Now a cache can expose itself to:
* another application in the same orbit

And less importantly (due to caches being VPC-private)
* an IP block
* all NAT-ed applications in another region of the same orbit

The latter are breadcrumbs for other internet-facing bits (i.e. `public_ports`, RDS).


Fixes #5 