### PR TITLE
RDS Decorator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pycrypto==2.6.1
 python-dateutil==2.5.3
 six==1.10.0
 splitstream==1.2.1
+tldextract==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ botocore==1.4.51
 docutils==0.12
 futures==3.0.5
 jmespath==0.9.0
+pycrypto==2.6.1
 python-dateutil==2.5.3
 six==1.10.0
 splitstream==1.2.1

--- a/sample/app/http-env-echo-postgres.json
+++ b/sample/app/http-env-echo-postgres.json
@@ -1,0 +1,30 @@
+{
+  "name": "http-env-echo",
+  "health_check": "HTTP:80/",
+  "instance_type": "t2.nano",
+  "instance_min": 1,
+  "instance_max": 1,
+  "services": {
+    "http-env-echo": {
+      "image": "pwagner/http-env-echo",
+      "ports": {
+        "80": 8080
+      }
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    }
+  },
+  "databases": {
+    "somedb": {
+      "encrypted": false,
+      "public": true,
+      "global": "us-east-1",
+      "clients": [
+        "99.232.67.89/32"
+      ]
+    }
+  }
+}

--- a/src/spacel/aws/clients.py
+++ b/src/spacel/aws/clients.py
@@ -53,6 +53,14 @@ class ClientCache(object):
         """
         return self._client('dynamodb', region)
 
+    def acm(self, region):
+        """
+        Get AWS Certificate Manager client.
+        :param region:  AWS region.
+        :return: ACM Client.
+        """
+        return self._client('acm', region)
+
     def _client(self, client_type, region):
         client_cache = self._clients[client_type]
         cached = client_cache.get(region)

--- a/src/spacel/aws/clients.py
+++ b/src/spacel/aws/clients.py
@@ -37,6 +37,22 @@ class ClientCache(object):
         """
         return self._resource('s3', region)
 
+    def kms(self, region):
+        """
+        Get KMS client.
+        :param region:  AWS region.
+        :return: KMS Client.
+        """
+        return self._client('kms', region)
+
+    def dynamodb(self, region):
+        """
+        Get DynamoDb client.
+        :param region:  AWS region.
+        :return: DynamoDb Client.
+        """
+        return self._client('dynamodb', region)
+
     def _client(self, client_type, region):
         client_cache = self._clients[client_type]
         cached = client_cache.get(region)

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -483,6 +483,8 @@
                 {"Ref": "AWS::StackName"},
                 "\":\"Asg\"},",
                 "\"caches\":{",
+                "},",
+                "\"databases\":{",
                 "}",
                 {"Ref": "UserData"},
                 "}"

--- a/src/spacel/cloudformation/tables.template
+++ b/src/spacel/cloudformation/tables.template
@@ -8,6 +8,35 @@
     }
   },
   "Resources": {
+    "PasswordsTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "TableName": {
+          "Fn::Join": [
+            "-", [
+              {"Ref": "Orbit"},
+              "passwords"
+            ]
+          ]
+        },
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "name",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "name",
+            "KeyType": "HASH"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": "1",
+          "WriteCapacityUnits": "1"
+        }
+      }
+    },
     "ServicesTable": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -14,6 +14,7 @@ from spacel.provision.template import (AppTemplate, BastionTemplate,
                                        VpcTemplate)
 from spacel.provision.alarm import AlarmFactory
 from spacel.provision.db import CacheFactory, RdsFactory
+from spacel.security import KmsCrypto, KmsKeyFactory, PasswordManager
 
 
 def main(args, in_stream):
@@ -42,8 +43,12 @@ def main(args, in_stream):
                                      pagerduty_api_key,
                                      lambda_up)
     ingress_factory = IngressResourceFactory(clients)
+    kms_key_factory = KmsKeyFactory(clients)
+    kms_crypto = KmsCrypto(clients, kms_key_factory)
+    password_manager = PasswordManager(clients, kms_crypto)
+
     cache_factory = CacheFactory(ingress_factory)
-    rds_factory = RdsFactory(ingress_factory)
+    rds_factory = RdsFactory(ingress_factory, password_manager)
 
     # Templates:
     ami_finder = AmiFinder()

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -48,7 +48,7 @@ def main(args, in_stream):
     password_manager = PasswordManager(clients, kms_crypto)
 
     cache_factory = CacheFactory(ingress_factory)
-    rds_factory = RdsFactory(ingress_factory, password_manager)
+    rds_factory = RdsFactory(clients, ingress_factory, password_manager)
 
     # Templates:
     ami_finder = AmiFinder()

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -13,7 +13,7 @@ from spacel.provision.template import (AppTemplate, BastionTemplate,
                                        IngressResourceFactory, TablesTemplate,
                                        VpcTemplate)
 from spacel.provision.alarm import AlarmFactory
-from spacel.provision.cache import CacheFactory
+from spacel.provision.db import CacheFactory, RdsFactory
 
 
 def main(args, in_stream):
@@ -43,11 +43,13 @@ def main(args, in_stream):
                                      lambda_up)
     ingress_factory = IngressResourceFactory(clients)
     cache_factory = CacheFactory(ingress_factory)
+    rds_factory = RdsFactory(ingress_factory)
 
     # Templates:
     ami_finder = AmiFinder()
 
-    app_template = AppTemplate(ami_finder, alarm_factory, cache_factory)
+    app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,
+                               rds_factory)
     bastion_template = BastionTemplate(ami_finder)
     tables_template = TablesTemplate()
     vpc_template = VpcTemplate()

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -50,6 +50,7 @@ class SpaceApp(object):
             logger.warn('Invalid service: %s', service_name)
         self.alarms = params.get('alarms', {})
         self.caches = params.get('caches', {})
+        self.databases = params.get('databases', {})
 
     @property
     def full_name(self):

--- a/src/spacel/provision/__init__.py
+++ b/src/spacel/provision/__init__.py
@@ -8,3 +8,10 @@ from .s3 import LambdaUploader, TemplateUploader
 
 def clean_name(name):
     return re.sub('[^A-Za-z0-9]', '', name)
+
+
+def bool_param(params, name, default):
+    val = params.get(name)
+    if val is None:
+        return default
+    return bool(val)

--- a/src/spacel/provision/__init__.py
+++ b/src/spacel/provision/__init__.py
@@ -1,3 +1,4 @@
+import base64
 import re
 
 from .changesets import ChangeSetEstimator
@@ -15,3 +16,7 @@ def bool_param(params, name, default):
     if val is None:
         return default
     return bool(val)
+
+
+def base64_encode(some_string):
+    return base64.b64encode(some_string).decode('utf-8').strip()

--- a/src/spacel/provision/__init__.py
+++ b/src/spacel/provision/__init__.py
@@ -18,5 +18,9 @@ def bool_param(params, name, default):
     return bool(val)
 
 
-def base64_encode(some_string):
-    return base64.b64encode(some_string).decode('utf-8').strip()
+def base64_encode(some_data):
+    return base64.b64encode(some_data).decode('utf-8').strip()
+
+
+def base64_decode(some_string):
+    return base64.b64decode(some_string)

--- a/src/spacel/provision/cache/__init__.py
+++ b/src/spacel/provision/cache/__init__.py
@@ -1,1 +1,0 @@
-from .factory import CacheFactory

--- a/src/spacel/provision/db/__init__.py
+++ b/src/spacel/provision/db/__init__.py
@@ -1,0 +1,2 @@
+from .cache import CacheFactory
+from .rds import RdsFactory

--- a/src/spacel/provision/db/base.py
+++ b/src/spacel/provision/db/base.py
@@ -1,0 +1,27 @@
+import logging
+
+logger = logging.getLogger('spacel.provision.db')
+
+
+class BaseTemplateDecorator(object):
+    def __init__(self, ingress):
+        self._ingress = ingress
+
+    def _add_client_resources(self, resources, app, region, port, params,
+                              sg_ref):
+        clients = params.get('clients', ())
+        ingress_resources = self._ingress.ingress_resources(app.orbit,
+                                                            region,
+                                                            port,
+                                                            clients,
+                                                            sg_ref=sg_ref)
+        logger.debug('Adding %s ingress rules.', len(ingress_resources))
+        resources.update(ingress_resources)
+
+    @staticmethod
+    def _user_data(resources):
+        return (resources['Lc']
+                ['Properties']
+                ['UserData']
+                ['Fn::Base64']
+                ['Fn::Join'][1])

--- a/src/spacel/provision/db/rds.py
+++ b/src/spacel/provision/db/rds.py
@@ -1,0 +1,150 @@
+import logging
+from spacel.provision import clean_name, bool_param
+from spacel.provision.db.base import BaseTemplateDecorator
+
+logger = logging.getLogger('spacel.provision.rds.factory')
+
+DEFAULT_VERSIONS = {
+    'mysql': '5.7.10',
+    'postgres': '9.5.2'
+}
+
+DEFAULT_PORTS = {
+    'mysql': 3306,
+    'postgres': 5432
+}
+
+
+class RdsFactory(BaseTemplateDecorator):
+    def add_rds(self, app, region, template, databases):
+        if not databases:
+            logger.debug('No databases specified.')
+            return
+
+        params = template['Parameters']
+        resources = template['Resources']
+        app_name = app.name
+        orbit_name = app.orbit.name
+
+        user_data = self._user_data(resources)
+        db_intro = user_data.index('"databases":{') + 1
+
+        added_databases = 0
+        for name, db_params in databases.items():
+            db_global = db_params.get('global')
+            if db_global and db_global != region:
+                continue
+
+            db_type = db_params.get('type', 'postgres')
+
+            db_version = db_params.get('version', DEFAULT_VERSIONS.get(db_type))
+            if not db_version:
+                logger.warn('Database "%s" has invalid "version".', name)
+                continue
+
+            db_port = db_params.get('port', DEFAULT_PORTS.get(db_type))
+            if not db_port:
+                logger.warn('Database "%s" has invalid "port".', name)
+                continue
+
+            instance_type = self._instance_type(db_params)
+            multi_az = bool_param(db_params, 'multi_az', False)
+            encrypted = bool_param(db_params, 'encrypted', False)
+            storage_size = db_params.get('size', '5')
+            storage_type = db_params.get('storage_type', 'gp2')
+            storage_iops = db_params.get('iops', None)
+            db_username = db_params.get('username', name)
+
+            public = bool_param(db_params, 'public', False)
+            db_subnet_group = '%sRdsSubnetGroup' % (public and 'Public'
+                                                    or 'Private')
+
+            rds_resource = 'Db%s' % clean_name(name)
+            rds_desc = '%s for %s in %s' % (name, app_name, orbit_name)
+            logger.debug('Creating database "%s".', name)
+
+            # Create a parameter for the database password:
+            password_param = '%sPassword' % rds_resource
+            params[password_param] = {
+                'Type': 'String',
+                'Description': 'Password for database %s' % name,
+                'NoEcho': True,
+                # FIXME: not this
+                'Default': 'Writeme123'
+            }
+
+            # Security group for database:
+            rds_sg_resource = '%sSg' % rds_resource
+            resources[rds_sg_resource] = {
+                'Type': 'AWS::EC2::SecurityGroup',
+                'Properties': {
+                    'GroupDescription': rds_desc,
+                    'VpcId': {'Ref': 'VpcId'},
+                    'SecurityGroupIngress': [
+                        {
+                            'IpProtocol': 'tcp',
+                            'FromPort': db_port,
+                            'ToPort': db_port,
+                            'SourceSecurityGroupId': {'Ref': 'Sg'}
+                        }
+                    ]
+                }
+            }
+
+            rds_params = {
+                'AllocatedStorage': storage_size,
+                'AllowMajorVersionUpgrade': False,
+                'AutoMinorVersionUpgrade': True,
+                'DBInstanceClass': instance_type,
+                'DBName': name,
+                'DBSubnetGroupName': {'Ref': db_subnet_group},
+                'Engine': db_type,
+                'EngineVersion': db_version,
+                'MasterUsername': db_username,
+                'MasterUserPassword': {'Ref': password_param},
+                'MultiAZ': multi_az,
+                'Port': db_port,
+                'PubliclyAccessible': public,
+                'StorageEncrypted': encrypted,
+                'StorageType': storage_type,
+                'VPCSecurityGroups': [{'Ref': rds_sg_resource}]
+            }
+
+            if storage_iops:
+                rds_params['Iops'] = storage_iops
+                if storage_type != 'io1':
+                    logger.warn('Overriding "storage_type" of "%s": ' +
+                                '"iops" requires io1.', name)
+                    rds_params['StorageType'] = 'io1'
+
+            # Workaround for the instance_type default not supporting crypt
+            # Other t2's fail, but at least that's the user's fault.
+            if encrypted and instance_type == 'db.t2.micro':
+                logger.warn('Overriding "instance_type" of "%s": ' +
+                            '"encrypted" requires t2.large".', name)
+                rds_params['DBInstanceClass'] = 'db.t2.large'
+
+            resources[rds_resource] = {
+                'Type': 'AWS::RDS::DBInstance',
+                'Properties': rds_params
+            }
+
+            # Inject a labeled reference to this cache replication group:
+            # Read this backwards, and note the trailing comma.
+            user_data.insert(db_intro, ',')
+            user_data.insert(db_intro, '","region": "%s"}' % region)
+            user_data.insert(db_intro, {'Ref': rds_resource})
+            user_data.insert(db_intro, '"%s":{"name":"' % name)
+            added_databases += 1
+
+            self._add_client_resources(resources, app, region, db_port,
+                                       db_params, rds_sg_resource)
+        if added_databases:
+            del user_data[db_intro + (4 * added_databases) - 1]
+
+    @staticmethod
+    def _instance_type(params):
+        instance_type = params.get('instance_type', 'db.t2.micro')
+        if not instance_type.startswith('db.'):
+            instance_type = 'db.' + instance_type
+        return instance_type

--- a/src/spacel/provision/orbit/gdh.py
+++ b/src/spacel/provision/orbit/gdh.py
@@ -11,11 +11,6 @@ class GitDeployHooksOrbitFactory(BaseCloudFormationFactory):
     """
     Queries existing orbital VPCs built by git-deploy.
     """
-
-    def __init__(self, clients, change_sets, uploader):
-        super(GitDeployHooksOrbitFactory, self).__init__(clients, change_sets,
-                                                         uploader)
-
     def get_orbit(self, orbit, regions=None):
         regions = regions or orbit.regions
         for region in regions:

--- a/src/spacel/provision/orbit/space.py
+++ b/src/spacel/provision/orbit/space.py
@@ -47,9 +47,8 @@ class SpaceElevatorOrbitFactory(BaseCloudFormationFactory):
 
             updates[region] = self._stack(stack_name, region, template)
 
-        # FIXME: 'region' has the wrong value here
         logger.debug('Requested %s in %s, waiting for provisioning...',
-                     stack_name, region)
+                     stack_name, regions)
         self._wait_for_updates(stack_name, updates)
         logger.debug('Provisioned %s in %s.', stack_name, region)
 

--- a/src/spacel/provision/provision.py
+++ b/src/spacel/provision/provision.py
@@ -18,8 +18,10 @@ class CloudProvisioner(BaseCloudFormationFactory):
         app_name = app.full_name
         updates = {}
         for region in app.regions:
-            template = self._app.app(app, region)
-            updates[region] = self._stack(app_name, region, template)
+            template, secret_params = self._app.app(app, region)
+
+            updates[region] = self._stack(app_name, region, template,
+                                          secret_parameters=secret_params)
         self._wait_for_updates(app_name, updates)
 
     def delete_app(self, app):

--- a/src/spacel/provision/rds/__init__.py
+++ b/src/spacel/provision/rds/__init__.py
@@ -1,0 +1,1 @@
+from .factory import RdsFactory

--- a/src/spacel/provision/rds/__init__.py
+++ b/src/spacel/provision/rds/__init__.py
@@ -1,1 +1,0 @@
-from .factory import RdsFactory

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -7,10 +7,11 @@ from spacel.provision.template.base import BaseTemplateCache
 
 
 class AppTemplate(BaseTemplateCache):
-    def __init__(self, ami_finder, alarm_factory, cache_factory):
+    def __init__(self, ami_finder, alarm_factory, cache_factory, rds_factory):
         super(AppTemplate, self).__init__(ami_finder=ami_finder)
         self._alarm_factory = alarm_factory
         self._cache_factory = cache_factory
+        self._rds_factory = rds_factory
 
     def app(self, app, region):
         app_template = self.get('elb-service')
@@ -102,7 +103,7 @@ class AppTemplate(BaseTemplateCache):
         # Private ports:
         for private_port, protocols in app.private_ports.items():
             if (isinstance(private_port, six.string_types)
-                    and '-' in private_port):
+                and '-' in private_port):
                 from_port, to_port = private_port.split('-', 1)
                 port_label = private_port.replace('-', 'to')
             else:
@@ -136,6 +137,7 @@ class AppTemplate(BaseTemplateCache):
 
         self._alarm_factory.add_alarms(app_template, app.alarms)
         self._cache_factory.add_caches(app, region, app_template, app.caches)
+        self._rds_factory.add_rds(app, region, app_template, app.databases)
         return app_template
 
     def _user_data(self, params, app):

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -138,8 +138,7 @@ class AppTemplate(BaseTemplateCache):
 
         self._alarm_factory.add_alarms(app_template, app.alarms)
         self._cache_factory.add_caches(app, region, app_template, app.caches)
-        secret_params = self._rds_factory.add_rds(app, region, app_template,
-                                                  app.databases)
+        secret_params = self._rds_factory.add_rds(app, region, app_template)
         return app_template, secret_params
 
     def _user_data(self, params, app):

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -26,12 +26,15 @@ class AppTemplate(BaseTemplateCache):
         params['Orbit']['Default'] = orbit.name
         params['Service']['Default'] = app.name
         params['BastionSecurityGroup']['Default'] = orbit.bastion_sg(region)
-        params['PrivateCacheSubnetGroup']['Default'] = \
-            orbit.private_cache_subnet_group(region)
-        params['PublicRdsSubnetGroup']['Default'] = \
-            orbit.public_rds_subnet_group(region)
-        params['PrivateRdsSubnetGroup']['Default'] = \
-            orbit.private_rds_subnet_group(region)
+        cache_subnet_group = orbit.private_cache_subnet_group(region)
+        if cache_subnet_group:
+            params['PrivateCacheSubnetGroup']['Default'] = cache_subnet_group
+        public_rds_group = orbit.public_rds_subnet_group(region)
+        if public_rds_group:
+            params['PublicRdsSubnetGroup']['Default'] = public_rds_group
+        private_rds_group = orbit.private_rds_subnet_group(region)
+        if private_rds_group:
+            params['PrivateRdsSubnetGroup']['Default'] = private_rds_group
 
         # Inject parameters:
         params['ElbScheme']['Default'] = app.scheme
@@ -103,8 +106,8 @@ class AppTemplate(BaseTemplateCache):
 
         # Private ports:
         for private_port, protocols in app.private_ports.items():
-            if (isinstance(private_port, six.string_types)
-                    and '-' in private_port):
+            port_is_string = isinstance(private_port, six.string_types)
+            if port_is_string and '-' in private_port:
                 from_port, to_port = private_port.split('-', 1)
                 port_label = private_port.replace('-', 'to')
             else:

--- a/src/spacel/provision/template/ingress_resource.py
+++ b/src/spacel/provision/template/ingress_resource.py
@@ -70,8 +70,9 @@ class IngressResourceFactory(object):
             if client in orbit.regions:
                 logger.debug('Adding access from %s in %s.', orbit.name, client)
                 for nat_index, nat_eip in orbit.nat_eips(client).items():
-                    ingress_resource('Nat%s%s' % (client, nat_index),
-                                     CidrIp='%s/32' % nat_eip)
+                    if nat_eip:
+                        ingress_resource('Nat%s%s' % (client, nat_index),
+                                         CidrIp='%s/32' % nat_eip)
                 continue
 
             # An application in the same orbit:

--- a/src/spacel/security/__init__.py
+++ b/src/spacel/security/__init__.py
@@ -1,0 +1,4 @@
+from .kms_crypt import KmsCrypto, EncryptedPayload
+from .kms_key import KmsKeyFactory
+from .password import PasswordManager
+

--- a/src/spacel/security/acm.py
+++ b/src/spacel/security/acm.py
@@ -1,0 +1,70 @@
+import logging
+import re
+from tldextract import extract
+
+logger = logging.getLogger('spacel.security.acm')
+
+
+class AcmCertificates(object):
+    def __init__(self, clients):
+        self._clients = clients
+
+    def get_certificate(self, region, hostname):
+        logger.debug('Looking up certificate for "%s".', hostname)
+
+        host_wildcards = self._get_wildcards(hostname)
+        logger.debug('Resolved wildcards: %s', host_wildcards)
+        acm = self._clients.acm(region)
+
+        wildcard_cert = None
+        wildcard_count = 100
+
+        # Iterate certificates:
+        for acm_cert in self._get_certificates(acm):
+            cert_domain = acm_cert['DomainName']
+            cert_arn = acm_cert['CertificateArn']
+
+            # Stop search if exact match is found:
+            if cert_domain == hostname:
+                logger.debug('Found exact match for "%s": %s"', hostname,
+                             cert_arn)
+                return cert_arn
+
+            if cert_domain in host_wildcards:
+                star_count = cert_domain.count('*')
+                if star_count < wildcard_count:
+                    wildcard_count = star_count
+                    wildcard_cert = cert_arn
+
+        if wildcard_cert:
+            logger.debug('Found wildcard match for "%s": %s (%s)', hostname,
+                         wildcard_cert, wildcard_count)
+        return wildcard_cert
+
+    @staticmethod
+    def _get_wildcards(hostname):
+        extracted = extract('http://%s' % hostname)
+        if not extracted.subdomain:
+            return []
+
+        common_domain = [extracted.domain, extracted.suffix]
+
+        wildcards = []
+        # For each subdomain component:
+        split_subdomain = extracted.subdomain.split('.')
+        for i in range(len(split_subdomain)):
+            # Replace with wildcard, then concat to remaining bits:
+            wildcard_parts = ['*'] * (i + 1) + split_subdomain[i + 1:]
+            wildcard_parts += common_domain
+            wildcards.append('.'.join(wildcard_parts))
+
+        return wildcards
+
+    @staticmethod
+    def _get_certificates(acm):
+        certificate_pages = (acm.get_paginator('list_certificates')
+                             .paginate(CertificateStatuses=['ISSUED']))
+
+        for certificate_page in certificate_pages:
+            for certificate in certificate_page['CertificateSummaryList']:
+                yield certificate

--- a/src/spacel/security/kms_crypt.py
+++ b/src/spacel/security/kms_crypt.py
@@ -1,0 +1,89 @@
+from botocore.exceptions import ClientError
+from Crypto import Random
+from Crypto.Cipher import AES
+from Crypto.Util.py3compat import bchr, bord
+import logging
+import six
+from spacel.security.payload import EncryptedPayload
+
+logger = logging.getLogger('spacel.security.kms_crypt')
+
+BLOCK_SIZE = AES.block_size
+CIPHER_MODE = AES.MODE_CBC
+
+
+class KmsCrypto(object):
+    """
+    Uses KMS to encrypt/decrypt data with AES-256.
+    """
+
+    def __init__(self, clients, kms_key):
+        self._kms_key = kms_key
+        self._clients = clients
+        self._random = Random.new()
+
+    def encrypt(self, app, region, plaintext):
+        # Get DEK:
+        logger.debug('Fetching fresh data key...')
+        try:
+            alias_name = self._kms_key.get_key_alias(app)
+            kms = self._clients.kms(region)
+            data_key = kms.generate_data_key(KeyId=alias_name,
+                                             KeySpec='AES_256')
+        except ClientError as e:
+            e_message = e.response['Error'].get('Message', '')
+            if 'is not found' in e_message:
+                # Key not found, create and try again:
+                self._kms_key.create_key(app, region)
+                return self.encrypt(app, region, plaintext)
+
+        # Encode and pad data:
+        encoding = 'bytes'
+        if isinstance(plaintext, six.string_types):
+            encoding = 'utf-8'
+            if six.PY3:  # pragma: no cover
+                plaintext = bytes(plaintext, encoding)
+            else:  # pragma: no cover
+                plaintext = plaintext.encode(encoding)
+        pad_length = BLOCK_SIZE - (len(plaintext) % BLOCK_SIZE)
+        padded = plaintext + (pad_length * bchr(pad_length))
+        logger.debug('Padded %s %s to %s.', len(plaintext), encoding,
+                     len(padded))
+
+        logger.debug('Encrypting data with data key...')
+        iv = self._random.read(BLOCK_SIZE)
+
+        cipher = AES.new(data_key['Plaintext'], CIPHER_MODE, iv)
+        ciphertext = cipher.encrypt(padded)
+
+        encrypted_key = data_key['CiphertextBlob']
+        return EncryptedPayload(iv, ciphertext, encrypted_key, region, encoding)
+
+    def decrypt_payload(self, payload):
+        return self.decrypt(payload.iv, payload.ciphertext, payload.key,
+                            payload.key_region, payload.encoding)
+
+    def decrypt(self, iv, ciphertext, key, key_region, encoding):
+        # Decrypt DEK:
+        logger.debug('Decrypting data key...')
+        kms = self._clients.kms(key_region)
+        decrypted_key = kms.decrypt(CiphertextBlob=key)
+
+        # Decrypt data:
+        cipher = AES.new(decrypted_key['Plaintext'], CIPHER_MODE, iv)
+        plaintext = cipher.decrypt(ciphertext)
+
+        # Remove pad:
+        pad_length = bord(plaintext[-1])
+        actual_pad = plaintext[-pad_length:]
+        expected_pad = bchr(pad_length) * pad_length
+        if actual_pad != expected_pad:
+            raise ValueError('Incorrect padding')
+        unpadded = plaintext[:-pad_length]
+
+        if encoding == 'bytes':
+            return unpadded
+        if six.PY3:  # pragma: no cover
+            return str(unpadded, encoding)
+        else:  # pragma: no cover
+            return unpadded.decode('utf-8')

--- a/src/spacel/security/kms_key.py
+++ b/src/spacel/security/kms_key.py
@@ -1,0 +1,75 @@
+import logging
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger('spacel.security.kms_key')
+
+
+class KmsKeyFactory(object):
+    def __init__(self, clients):
+        self._clients = clients
+
+    @staticmethod
+    def get_key_alias(app):
+        """
+        Get KMS alias for an application key.
+        :param app: Application.
+        :return: Key alias.
+        """
+        return 'alias/%s-%s' % (app.orbit.name, app.name)
+
+    def get_key(self, app, region):
+        """
+        Get a KMS key ARN, creating if necessary.
+        :param app: App descriptor.
+        :param region: Region.
+        :return: KMS key ARN.
+        """
+        alias_name = self.get_key_alias(app)
+        logger.debug('Finding key for "%s" in %s.', alias_name, region)
+        try:
+            kms = self._clients.kms(region)
+            existing_key = kms.describe_key(KeyId=alias_name)
+            logger.debug('Found existing key "%s" in %s.', alias_name, region)
+            existing_key = existing_key['KeyMetadata']
+            key_arn = existing_key['Arn']
+            if not existing_key['Enabled']:
+                logger.warn('Key %s is disabled.', key_arn)
+                return None
+            return key_arn
+        except ClientError as e:
+            e_message = e.response['Error'].get('Message', '')
+            if 'Invalid keyId' not in e_message:
+                raise e
+        logger.debug('Unable to find key "%s", creating...', alias_name)
+        return self.create_key(app, region)
+
+    def create_key(self, app, region):
+        """
+        Get a KMS key ARN, assuming it doesn't already exist.
+        :param app: App descriptor.
+        :param region: Region.
+        :return: KMS key ARN.
+        """
+        alias_name = self.get_key_alias(app)
+
+        kms = self._clients.kms(region)
+        new_key = kms.create_key()
+        key_arn = new_key['KeyMetadata']['Arn']
+
+        # Key created, set alias:
+        try:
+            kms.create_alias(
+                AliasName=alias_name,
+                TargetKeyId=key_arn
+            )
+        except ClientError as e:
+            # Key created, but couldn't get alias: cleanup.
+            logger.warn('Error applying alias, deleting orphan key: "%s".',
+                        key_arn)
+            kms.schedule_key_deletion(
+                KeyId=key_arn,
+                PendingWindowInDays=7
+            )
+            raise e
+        logger.debug('Created key "%s" in %s.', alias_name, region)
+        return key_arn

--- a/src/spacel/security/password.py
+++ b/src/spacel/security/password.py
@@ -1,0 +1,62 @@
+import logging
+from random import choice
+from spacel.security.payload import EncryptedPayload
+
+DICT = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789%^*(-_=+)'
+
+logger = logging.getLogger('spacel.security.password')
+
+
+class PasswordManager(object):
+    def __init__(self, clients, kms_crypt):
+        self._clients = clients
+        self._kms_crypt = kms_crypt
+
+    def get_password(self, app, region, label):
+        """
+        Get a password for an application in a region.
+        :param app:  Application.
+        :param region: Region.
+        :param label: Password label.
+        :return: Encrypted password.
+        """
+        name = app.name
+        logger.debug('Getting password for %s in %s.', label, name)
+        table_name = '%s-passwords' % app.orbit.name
+        password_name = '%s:%s' % (name, label)
+
+        dynamodb = self._clients.dynamodb(region)
+        existing_item = dynamodb.get_item(TableName=table_name,
+                                          Key={'name': {'S': password_name}}
+                                          ).get('Item')
+        if existing_item:
+            logger.debug('Found existing password for %s in %s.', label, name)
+            encrypted = EncryptedPayload.from_dynamodb_item(existing_item)
+
+            def decrypt_func():
+                return self._kms_crypt.decrypt_payload(encrypted)
+
+            return encrypted, decrypt_func
+
+        # Not found, generate:
+        logger.debug('Generating password for %s in %s.', label, name)
+        plaintext = self._generate_password(32)
+        encrypted_payload = self._kms_crypt.encrypt(app, region, plaintext)
+        password_item = encrypted_payload.dynamodb_item()
+        password_item['name'] = {'S': password_name}
+
+        # Persist encrypted password:
+        dynamodb.put_item(
+            TableName=table_name,
+            Item=password_item,
+            ConditionExpression='attribute_not_exists(ciphertext)')
+
+        # Plaintext can be returned _once_ without Decrypt() permission
+        return encrypted_payload, lambda: plaintext
+
+    def decrypt(self, encrypted_payload):
+        return self._kms_crypt.decrypt_payload(encrypted_payload)
+
+    @staticmethod
+    def _generate_password(length):
+        return ''.join([choice(DICT) for _ in range(length)])

--- a/src/spacel/security/password.py
+++ b/src/spacel/security/password.py
@@ -12,12 +12,13 @@ class PasswordManager(object):
         self._clients = clients
         self._kms_crypt = kms_crypt
 
-    def get_password(self, app, region, label):
+    def get_password(self, app, region, label, length=64):
         """
         Get a password for an application in a region.
         :param app:  Application.
         :param region: Region.
         :param label: Password label.
+        :param length: Password length.
         :return: Encrypted password.
         """
         name = app.name
@@ -40,7 +41,7 @@ class PasswordManager(object):
 
         # Not found, generate:
         logger.debug('Generating password for %s in %s.', label, name)
-        plaintext = self._generate_password(32)
+        plaintext = self._generate_password(length)
         encrypted_payload = self._kms_crypt.encrypt(app, region, plaintext)
         password_item = encrypted_payload.dynamodb_item()
         password_item['name'] = {'S': password_name}

--- a/src/spacel/security/password.py
+++ b/src/spacel/security/password.py
@@ -1,5 +1,7 @@
+from botocore.exceptions import ClientError
 import logging
 from random import choice
+
 from spacel.security.payload import EncryptedPayload
 
 DICT = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789%^*(-_=+)'
@@ -12,7 +14,7 @@ class PasswordManager(object):
         self._clients = clients
         self._kms_crypt = kms_crypt
 
-    def get_password(self, app, region, label, length=64):
+    def get_password(self, app, region, label, length=64, generate=True):
         """
         Get a password for an application in a region.
         :param app:  Application.
@@ -39,6 +41,9 @@ class PasswordManager(object):
 
             return encrypted, decrypt_func
 
+        if not generate:
+            return None, lambda: None
+
         # Not found, generate:
         logger.debug('Generating password for %s in %s.', label, name)
         plaintext = self._generate_password(length)
@@ -54,6 +59,37 @@ class PasswordManager(object):
 
         # Plaintext can be returned _once_ without Decrypt() permission
         return encrypted_payload, lambda: plaintext
+
+    def set_password(self, app, region, label, password_func):
+        name = app.name
+        logger.debug('Setting password for %s in %s.', label, name)
+        table_name = '%s-passwords' % app.orbit.name
+        password_name = '%s:%s' % (name, label)
+
+        dynamodb = self._clients.dynamodb(region)
+        existing_item = dynamodb.get_item(TableName=table_name,
+                                          Key={'name': {'S': password_name}}
+                                          ).get('Item')
+        if existing_item:
+            logger.warn('Existing password found for %s in %s, skipping.',
+                        label, name)
+            return False
+
+        plaintext = password_func()
+        encrypted_payload = self._kms_crypt.encrypt(app, region, plaintext)
+        password_item = encrypted_payload.dynamodb_item()
+        password_item['name'] = {'S': password_name}
+
+        # Persist encrypted password:
+        try:
+            dynamodb.put_item(
+                TableName=table_name,
+                Item=password_item,
+                ConditionExpression='attribute_not_exists(ciphertext)')
+            return True
+        except ClientError as e:
+            logger.warn('Error saving encrypted password: %s', e)
+            return False
 
     def decrypt(self, encrypted_payload):
         return self._kms_crypt.decrypt_payload(encrypted_payload)

--- a/src/spacel/security/payload.py
+++ b/src/spacel/security/payload.py
@@ -1,5 +1,5 @@
 import json
-from spacel.provision import base64_encode
+from spacel.provision import base64_decode, base64_encode
 
 
 class EncryptedPayload(object):
@@ -36,3 +36,14 @@ class EncryptedPayload(object):
             'ciphertext': base64_encode(self.ciphertext),
             'encoding': self.encoding,
         })
+
+    @staticmethod
+    def from_json(json_string):
+        json_obj = json.loads(json_string)
+        return EncryptedPayload(
+            base64_decode(json_obj['iv']),
+            base64_decode(json_obj['ciphertext']),
+            base64_decode(json_obj['key']),
+            json_obj['key_region'],
+            json_obj['encoding'],
+        )

--- a/src/spacel/security/payload.py
+++ b/src/spacel/security/payload.py
@@ -1,0 +1,38 @@
+import json
+from spacel.provision import base64_encode
+
+
+class EncryptedPayload(object):
+    def __init__(self, iv, ciphertext, key, key_region, encoding):
+        self.iv = iv
+        self.ciphertext = ciphertext
+        self.key = key
+        self.key_region = key_region
+        self.encoding = encoding
+
+    def dynamodb_item(self):
+        return {
+            'iv': {'B': self.iv},
+            'key': {'B': self.key},
+            'key_region': {'S': self.key_region},
+            'ciphertext': {'B': self.ciphertext},
+            'encoding': {'S': self.encoding}
+        }
+
+    @staticmethod
+    def from_dynamodb_item(item):
+        return EncryptedPayload(
+            item['iv']['B'],
+            item['ciphertext']['B'],
+            item['key']['B'],
+            item['key_region']['S'],
+            item['encoding']['S'])
+
+    def json(self):
+        return json.dumps({
+            'iv': base64_encode(self.iv),
+            'key': base64_encode(self.key),
+            'key_region': self.key_region,
+            'ciphertext': base64_encode(self.ciphertext),
+            'encoding': self.encoding,
+        })

--- a/src/spacel/security/payload.py
+++ b/src/spacel/security/payload.py
@@ -35,7 +35,7 @@ class EncryptedPayload(object):
             'key_region': self.key_region,
             'ciphertext': base64_encode(self.ciphertext),
             'encoding': self.encoding,
-        })
+        }, sort_keys=True)
 
     @staticmethod
     def from_json(json_string):

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -1,0 +1,18 @@
+import unittest
+
+from spacel.model import Orbit, SpaceApp
+
+ORBIT_NAME = 'test-orbit'
+APP_NAME = 'test-app'
+REGION = 'us-west-2'
+
+
+class BaseSpaceAppTest(unittest.TestCase):
+    def setUp(self):
+        self.orbit = Orbit({
+            'name': ORBIT_NAME
+        })
+
+        self.app = SpaceApp(self.orbit, {
+            'name': APP_NAME
+        })

--- a/src/test/aws/test_clients.py
+++ b/src/test/aws/test_clients.py
@@ -46,3 +46,8 @@ class TestClientCache(unittest.TestCase):
         self.clients._client = MagicMock()
         self.clients.dynamodb(REGION)
         self.clients._client.assert_called_with('dynamodb', REGION)
+
+    def test_acm(self):
+        self.clients._client = MagicMock()
+        self.clients.acm(REGION)
+        self.clients._client.assert_called_with('acm', REGION)

--- a/src/test/aws/test_clients.py
+++ b/src/test/aws/test_clients.py
@@ -1,9 +1,9 @@
 import unittest
+from mock import patch, MagicMock
 
-from mock import patch
 from spacel.aws.clients import ClientCache
 
-REGION = 'us-east-1'
+from test import REGION
 
 
 class TestClientCache(unittest.TestCase):
@@ -36,3 +36,13 @@ class TestClientCache(unittest.TestCase):
         self.clients.s3(REGION)
         self.clients.s3(REGION)
         self.assertEqual(1, mock_boto3.resource.call_count)
+
+    def test_kms(self):
+        self.clients._client = MagicMock()
+        self.clients.kms(REGION)
+        self.clients._client.assert_called_with('kms', REGION)
+
+    def test_dynamodb(self):
+        self.clients._client = MagicMock()
+        self.clients.dynamodb(REGION)
+        self.clients._client.assert_called_with('dynamodb', REGION)

--- a/src/test/provision/__init__.py
+++ b/src/test/provision/__init__.py
@@ -1,0 +1,13 @@
+def normalize_cf(cf_json):
+    if isinstance(cf_json, dict):
+        ref = cf_json.get('Ref')
+        if ref is not None:
+            return ref
+        normalized = {}
+        for key, value in cf_json.items():
+            normalized[key] = normalize_cf(value)
+        return normalized
+    if isinstance(cf_json, list):
+        return [normalize_cf(f) for f in cf_json]
+
+    return cf_json

--- a/src/test/provision/db/__init__.py
+++ b/src/test/provision/db/__init__.py
@@ -1,0 +1,38 @@
+import json
+from mock import MagicMock
+
+from spacel.provision.template import IngressResourceFactory
+
+from test import BaseSpaceAppTest
+from test.provision import normalize_cf
+
+
+class BaseDbTest(BaseSpaceAppTest):
+    def setUp(self):
+        super(BaseDbTest, self).setUp()
+        self.user_data_params = []
+        self.resources = {
+            'Lc': {
+                'Properties': {
+                    'UserData': {
+                        'Fn::Base64': {
+                            'Fn::Join': [
+                                '', self.user_data_params
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        self.parameters = {}
+        self.template = {
+            'Parameters': self.parameters,
+            'Resources': self.resources
+        }
+
+        self.ingress = MagicMock(spec=IngressResourceFactory)
+
+    def _user_data(self):
+        user_data_params = normalize_cf(self.user_data_params)
+        user_data = json.loads(''.join(user_data_params))
+        return user_data

--- a/src/test/provision/db/test_cache.py
+++ b/src/test/provision/db/test_cache.py
@@ -3,7 +3,7 @@ from mock import MagicMock
 import unittest
 
 from spacel.model import SpaceApp
-from spacel.provision.cache.factory import CacheFactory
+from spacel.provision.db.cache import CacheFactory
 from spacel.provision.template import IngressResourceFactory
 
 CACHE_NAME = 'test-cache'

--- a/src/test/provision/db/test_cache.py
+++ b/src/test/provision/db/test_cache.py
@@ -1,70 +1,45 @@
-import json
-from mock import MagicMock
-import unittest
-
-from spacel.model import SpaceApp
 from spacel.provision.db.cache import CacheFactory
-from spacel.provision.template import IngressResourceFactory
+from test import REGION
+from test.provision.db import BaseDbTest
 
 CACHE_NAME = 'test-cache'
-REGION = 'us-west-2'
 
 
-class TestCacheFactory(unittest.TestCase):
+class TestCacheFactory(BaseDbTest):
     def setUp(self):
-        self.user_data_params = [
+        super(TestCacheFactory, self).setUp()
+        self.user_data_params += [
             '{',
             '\"caches\":{',
             '} }'
         ]
-        self.resources = {
-            'Lc': {
-                'Properties': {
-                    'UserData': {
-                        'Fn::Base64': {
-                            'Fn::Join': [
-                                '', self.user_data_params
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-        self.template = {'Resources': self.resources}
         self.cache_params = {}
         self.caches = {
             CACHE_NAME: self.cache_params
         }
-        self.app = MagicMock(spec=SpaceApp)
-        self.app.name = 'test-app'
-        self.app.orbit = MagicMock()
-        self.app.orbit.name = 'test-orbit'
 
-        self.ingress = MagicMock(spec=IngressResourceFactory)
         self.cache_factory = CacheFactory(self.ingress)
 
     def test_add_caches_noop(self):
         del self.caches[CACHE_NAME]
-        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template,
+                                      self.caches)
         self.assertEquals(1, len(self.resources))
 
     def test_add_caches_invalid_replicas(self):
         self.cache_params['replicas'] = 'meow'
 
-        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template,
+                                      self.caches)
         self.assertEquals(1, len(self.resources))
 
     def test_add_caches(self):
-        self.cache_factory.add_caches(self.app, REGION, self.template, self.caches)
+        self.cache_factory.add_caches(self.app, REGION, self.template,
+                                      self.caches)
         self.assertEquals(3, len(self.resources))
 
-        # Resolve {'Ref':}s to a string:
-        for index, user_data in enumerate(self.user_data_params):
-            if isinstance(user_data, dict):
-                self.user_data_params[index] = user_data['Ref']
-
         # UserData should be valid JSON, `caches` should reference
-        user_data = json.loads(''.join(self.user_data_params))
+        user_data = self._user_data()
         self.assertEquals('Cachetestcache', user_data['caches'][CACHE_NAME])
 
     def test_replicas_invalid(self):
@@ -86,9 +61,3 @@ class TestCacheFactory(unittest.TestCase):
     def test_instance_type_missing_ha(self):
         instance_type = self.cache_factory._instance_type({}, True)
         self.assertEquals('cache.m3.medium', instance_type)
-
-    def test_instance_type_missing_ha(self):
-        instance_type = self.cache_factory._instance_type({
-            'instance_type': 'm3.large'
-        }, True)
-        self.assertEquals('cache.m3.large', instance_type)

--- a/src/test/provision/db/test_rds.py
+++ b/src/test/provision/db/test_rds.py
@@ -1,0 +1,74 @@
+import unittest
+import json
+from mock import MagicMock
+from spacel.model import SpaceApp
+from spacel.provision.db.rds import RdsFactory
+from spacel.provision.template import IngressResourceFactory
+
+DB_NAME = 'test-db'
+REGION = 'us-west-2'
+
+
+class TestRdsFactory(unittest.TestCase):
+    def setUp(self):
+        self.user_data_params = [
+            '{',
+            '\"databases\":{',
+            '} }'
+        ]
+        self.resources = {
+            'Lc': {
+                'Properties': {
+                    'UserData': {
+                        'Fn::Base64': {
+                            'Fn::Join': [
+                                '', self.user_data_params
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        self.parameters = {}
+        self.template = {
+            'Parameters': self.parameters,
+            'Resources': self.resources
+        }
+        self.db_params = {}
+        self.databases = {
+            DB_NAME: self.db_params
+        }
+
+        self.app = MagicMock(spec=SpaceApp)
+        self.app.name = 'test-app'
+        self.app.orbit = MagicMock()
+        self.app.orbit.name = 'test-orbit'
+
+        self.ingress = MagicMock(spec=IngressResourceFactory)
+        self.rds_factory = RdsFactory(self.ingress)
+
+    def test_add_rds(self):
+        self.rds_factory.add_rds(self.app, REGION, self.template,
+                                 self.databases)
+        self.assertEquals(3, len(self.resources))
+
+        # Resolve {'Ref':}s to a string:
+        user_data_params = normalize(self.user_data_params)
+        user_data = json.loads(''.join(user_data_params))
+        db_user_data = user_data['databases'][DB_NAME]
+        self.assertEquals('Dbtestdb', db_user_data['name'])
+
+
+def normalize(cf_json):
+    if isinstance(cf_json, dict):
+        ref = cf_json.get('Ref')
+        if ref is not None:
+            return ref
+        normalized = {}
+        for key, value in cf_json.items():
+            normalized[key] = normalize(value)
+        return normalized
+    if isinstance(cf_json, list):
+        return [normalize(f) for f in cf_json]
+
+    return cf_json

--- a/src/test/provision/db/test_rds.py
+++ b/src/test/provision/db/test_rds.py
@@ -1,51 +1,28 @@
-import unittest
-import json
 from mock import MagicMock
-from spacel.model import SpaceApp
+
+from spacel.aws import ClientCache
 from spacel.provision.db.rds import RdsFactory
-from spacel.provision.template import IngressResourceFactory
 from spacel.security import EncryptedPayload, PasswordManager
+from test import REGION
+from test.provision.db import BaseDbTest
 
 DB_NAME = 'test-db'
-REGION = 'us-west-2'
 
 
-class TestRdsFactory(unittest.TestCase):
+class TestRdsFactory(BaseDbTest):
     def setUp(self):
-        self.user_data_params = [
+        super(TestRdsFactory, self).setUp()
+        self.user_data_params += [
             '{',
             '\"databases\":{',
             '} }'
         ]
-        self.resources = {
-            'Lc': {
-                'Properties': {
-                    'UserData': {
-                        'Fn::Base64': {
-                            'Fn::Join': [
-                                '', self.user_data_params
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-        self.parameters = {}
-        self.template = {
-            'Parameters': self.parameters,
-            'Resources': self.resources
-        }
-        self.db_params = {}
 
-        self.app = MagicMock(spec=SpaceApp)
-        self.app.name = 'test-app'
-        self.app.orbit = MagicMock()
-        self.app.orbit.name = 'test-orbit'
+        self.db_params = {}
         self.app.databases = {
             DB_NAME: self.db_params
         }
 
-        self.ingress = MagicMock(spec=IngressResourceFactory)
         self.password_manager = MagicMock(spec=PasswordManager)
         self.password_manager.get_password.return_value = EncryptedPayload(
             b'1234567890123456',
@@ -54,29 +31,20 @@ class TestRdsFactory(unittest.TestCase):
             'us-east-1',
             'utf-8'
         ), lambda: 'test-password'
-        self.rds_factory = RdsFactory(self.ingress, self.password_manager)
+
+        self.clients = MagicMock(spec=ClientCache)
+        self.rds_factory = RdsFactory(self.clients, self.ingress,
+                                      self.password_manager)
+
+    def test_add_rds_noop(self):
+        self.app.databases = {}
+        self.rds_factory.add_rds(self.app, REGION, self.template)
 
     def test_add_rds(self):
         self.rds_factory.add_rds(self.app, REGION, self.template)
         self.assertEquals(3, len(self.resources))
 
         # Resolve {'Ref':}s to a string:
-        user_data_params = normalize(self.user_data_params)
-        user_data = json.loads(''.join(user_data_params))
+        user_data = self._user_data()
         db_user_data = user_data['databases'][DB_NAME]
         self.assertEquals('Dbtestdb', db_user_data['name'])
-
-
-def normalize(cf_json):
-    if isinstance(cf_json, dict):
-        ref = cf_json.get('Ref')
-        if ref is not None:
-            return ref
-        normalized = {}
-        for key, value in cf_json.items():
-            normalized[key] = normalize(value)
-        return normalized
-    if isinstance(cf_json, list):
-        return [normalize(f) for f in cf_json]
-
-    return cf_json

--- a/src/test/provision/db/test_rds.py
+++ b/src/test/provision/db/test_rds.py
@@ -1,12 +1,16 @@
-from mock import MagicMock
+from botocore.exceptions import ClientError
+from mock import MagicMock, ANY
 
 from spacel.aws import ClientCache
 from spacel.provision.db.rds import RdsFactory
 from spacel.security import EncryptedPayload, PasswordManager
 from test import REGION
 from test.provision.db import BaseDbTest
+from test.security import CLIENT_ERROR
 
 DB_NAME = 'test-db'
+OTHER_REGION = 'us-east-1'
+RDS_ID = 'rds-123456'
 
 
 class TestRdsFactory(BaseDbTest):
@@ -22,6 +26,7 @@ class TestRdsFactory(BaseDbTest):
         self.app.databases = {
             DB_NAME: self.db_params
         }
+        self.app.regions = [REGION, OTHER_REGION]
 
         self.password_manager = MagicMock(spec=PasswordManager)
         self.password_manager.get_password.return_value = EncryptedPayload(
@@ -33,12 +38,92 @@ class TestRdsFactory(BaseDbTest):
         ), lambda: 'test-password'
 
         self.clients = MagicMock(spec=ClientCache)
+        self.cloudformation = MagicMock()
+        self.clients.cloudformation.return_value = self.cloudformation
         self.rds_factory = RdsFactory(self.clients, self.ingress,
                                       self.password_manager)
 
     def test_add_rds_noop(self):
         self.app.databases = {}
         self.rds_factory.add_rds(self.app, REGION, self.template)
+
+    def test_add_rds_invalid_version(self):
+        self.db_params['type'] = 'oracle'
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+        self.assertEquals(1, len(self.resources))
+
+    def test_add_rds_invalid_port(self):
+        self.db_params['port'] = 0
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+        self.assertEquals(1, len(self.resources))
+
+    def test_add_rds_storage_type(self):
+        self.db_params['iops'] = 100
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+        self.assertEquals(3, len(self.resources))
+        db_properties = self.resources['Dbtestdb']['Properties']
+        self.assertEquals(100, db_properties['Iops'])
+        self.assertEquals('io1', db_properties['StorageType'])
+
+    def test_add_rds_encryption(self):
+        self.db_params['encrypted'] = True
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+        self.assertEquals(3, len(self.resources))
+        db_properties = self.resources['Dbtestdb']['Properties']
+        self.assertEquals('db.t2.large', db_properties['DBInstanceClass'])
+
+    def test_add_rds_global_other_region_no_db(self):
+        self.db_params['global'] = OTHER_REGION
+        self.rds_factory._rds_id = MagicMock(return_value=None)
+
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+
+        # DB resource not added, no mention in user data:
+        self.assertEquals(1, len(self.resources))
+        self.assertNotIn(DB_NAME, self._user_data())
+
+    def test_add_rds_global_other_region_no_password(self):
+        self.db_params['global'] = OTHER_REGION
+        self.password_manager.get_password.return_value = None, None
+
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+
+        # DB resource not added, no mention in user data:
+        self.assertEquals(1, len(self.resources))
+        self.assertNotIn(DB_NAME, self._user_data())
+
+    def test_add_rds_global_other_region(self):
+        self.db_params['global'] = OTHER_REGION
+        self.rds_factory._rds_id = MagicMock(return_value=RDS_ID)
+
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+
+        # DB resource not added:
+        self.assertEquals(1, len(self.resources))
+        user_data = self._user_data()
+        db_user_data = user_data['databases'][DB_NAME]
+        self.assertEquals(RDS_ID, db_user_data['name'])
+
+    def test_add_rds_global_region(self):
+        self.db_params['global'] = REGION
+
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+
+        self.assertEquals(3, len(self.resources))
+        # Password is saved to other regions:
+        self.password_manager.set_password.assert_called_with(self.app,
+                                                              OTHER_REGION,
+                                                              'rds:test-db',
+                                                              ANY)
+        self.assertIn(OTHER_REGION, self.db_params['clients'])
+
+    def test_add_rds_global_region_concat(self):
+        self.db_params['global'] = REGION
+        self.db_params['clients'] = []
+
+        self.rds_factory.add_rds(self.app, REGION, self.template)
+
+        self.assertIn(OTHER_REGION, self.db_params['clients'])
 
     def test_add_rds(self):
         self.rds_factory.add_rds(self.app, REGION, self.template)
@@ -48,3 +133,34 @@ class TestRdsFactory(BaseDbTest):
         user_data = self._user_data()
         db_user_data = user_data['databases'][DB_NAME]
         self.assertEquals('Dbtestdb', db_user_data['name'])
+
+    def test_instance_type_default(self):
+        instance_type = self.rds_factory._instance_type(self.db_params)
+        self.assertEquals('db.t2.micro', instance_type)
+
+    def test_instance_type_prefix(self):
+        self.db_params['instance_type'] = 't2.small'
+        instance_type = self.rds_factory._instance_type(self.db_params)
+        self.assertEquals('db.t2.small', instance_type)
+
+    def test_rds_id(self):
+        self.cloudformation.describe_stack_resource.return_value = {
+            'StackResourceDetail': {
+                'PhysicalResourceId': RDS_ID
+            }
+        }
+        rds_id = self.rds_factory._rds_id(self.app, REGION, 'DbTestDb')
+        self.assertEquals(RDS_ID, rds_id)
+
+    def test_rds_id_not_found(self):
+        self.cloudformation.describe_stack_resource.side_effect = ClientError({
+            'Error': {'Message': 'Stack does not exist'}},
+            'DescribeStackResource')
+
+        rds_id = self.rds_factory._rds_id(self.app, REGION, 'DbTestDb')
+        self.assertIsNone(rds_id)
+
+    def test_rds_id_exception(self):
+        self.cloudformation.describe_stack_resource.side_effect = CLIENT_ERROR
+        self.assertRaises(ClientError, self.rds_factory._rds_id, self.app,
+                          REGION, 'DbTestDb')

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -5,7 +5,7 @@ from spacel.aws import AmiFinder
 from spacel.model import Orbit, SpaceApp, SpaceDockerService
 from spacel.provision.template.app import AppTemplate
 from spacel.provision.alarm import AlarmFactory
-from spacel.provision.cache import CacheFactory
+from spacel.provision.db import CacheFactory, RdsFactory
 from test.provision.template import SUBNETS
 
 REGION = 'us-east-1'
@@ -16,7 +16,9 @@ class TestAppTemplate(unittest.TestCase):
         self.ami_finder = MagicMock(spec=AmiFinder)
         self.alarms = MagicMock(spec=AlarmFactory)
         self.caches = MagicMock(spec=CacheFactory)
-        self.cache = AppTemplate(self.ami_finder, self.alarms, self.caches)
+        self.rds = MagicMock(spec=RdsFactory)
+        self.cache = AppTemplate(self.ami_finder, self.alarms, self.caches,
+                                 self.rds)
         base_template = self.cache.get('elb-service')
         self.base_resources = len(base_template['Resources'])
         self.orbit = Orbit({

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -9,6 +9,7 @@ from spacel.provision.db import CacheFactory, RdsFactory
 from test.provision.template import SUBNETS
 
 REGION = 'us-east-1'
+SUBNET_GROUP = 'subnet-123456'
 
 
 class TestAppTemplate(unittest.TestCase):
@@ -79,6 +80,30 @@ class TestAppTemplate(unittest.TestCase):
 
         block_devs = app['Resources']['Lc']['Properties']['BlockDeviceMappings']
         self.assertEquals(2, len(block_devs))
+
+    def test_app_cache_subnet_group(self):
+        self.orbit._private_cache_subnet_groups[REGION] = SUBNET_GROUP
+
+        app, _ = self.cache.app(self.app, REGION)
+        self.assertEquals(SUBNET_GROUP, (app['Parameters']
+                                         ['PrivateCacheSubnetGroup']
+                                         ['Default']))
+
+    def test_app_public_rds_subnet_group(self):
+        self.orbit._public_rds_subnet_groups[REGION] = SUBNET_GROUP
+
+        app, _ = self.cache.app(self.app, REGION)
+        self.assertEquals(SUBNET_GROUP, (app['Parameters']
+                                         ['PublicRdsSubnetGroup']
+                                         ['Default']))
+
+    def test_app_private_rds_subnet_group(self):
+        self.orbit._private_rds_subnet_groups[REGION] = SUBNET_GROUP
+
+        app, _ = self.cache.app(self.app, REGION)
+        self.assertEquals(SUBNET_GROUP, (app['Parameters']
+                                         ['PrivateRdsSubnetGroup']
+                                         ['Default']))
 
     def test_user_data(self):
         params = {}

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -32,7 +32,7 @@ class TestAppTemplate(unittest.TestCase):
         })
 
     def test_app(self):
-        app = self.cache.app(self.app, REGION)
+        app, _ = self.cache.app(self.app, REGION)
 
         app_resources = len(app['Resources'])
         self.assertEquals(self.base_resources, app_resources)
@@ -48,7 +48,7 @@ class TestAppTemplate(unittest.TestCase):
     def test_app_domain(self):
         self.app.hostnames = ('app.test.com',)
 
-        app = self.cache.app(self.app, REGION)
+        app, _ = self.cache.app(self.app, REGION)
 
         params = app['Parameters']
         self.assertEquals(params['VirtualHostDomain']['Default'], 'test.com.')
@@ -57,7 +57,7 @@ class TestAppTemplate(unittest.TestCase):
     def test_app_private_ports(self):
         self.app.private_ports = {123: ['TCP']}
 
-        app = self.cache.app(self.app, REGION)
+        app, _ = self.cache.app(self.app, REGION)
 
         sg_properties = app['Resources']['PrivatePort123TCP']['Properties']
         self.assertEquals(123, sg_properties['FromPort'])
@@ -66,7 +66,7 @@ class TestAppTemplate(unittest.TestCase):
     def test_app_private_ports_split(self):
         self.app.private_ports = {'123-456': ['TCP']}
 
-        app = self.cache.app(self.app, REGION)
+        app, _ = self.cache.app(self.app, REGION)
 
         sg_properties = app['Resources']['PrivatePort123to456TCP']['Properties']
         self.assertEquals('123', sg_properties['FromPort'])
@@ -75,7 +75,7 @@ class TestAppTemplate(unittest.TestCase):
     def test_app_instance_storage(self):
         self.app.instance_type = 'c1.medium'
 
-        app = self.cache.app(self.app, REGION)
+        app, _ = self.cache.app(self.app, REGION)
 
         block_devs = app['Resources']['Lc']['Properties']['BlockDeviceMappings']
         self.assertEquals(2, len(block_devs))

--- a/src/test/provision/test_provision.py
+++ b/src/test/provision/test_provision.py
@@ -17,7 +17,7 @@ class TestCloudProvisioner(unittest.TestCase):
         self.change_sets = MagicMock(spec=ChangeSetEstimator)
         self.templates = MagicMock(spec=TemplateUploader)
         self.app_template = MagicMock(spec=AppTemplate)
-        self.app_template.app.return_value = {}
+        self.app_template.app.return_value = {}, {}
 
         self.provisioner = CloudProvisioner(self.clients, self.change_sets,
                                             self.templates,

--- a/src/test/security/__init__.py
+++ b/src/test/security/__init__.py
@@ -1,3 +1,4 @@
+from botocore.exceptions import ClientError
 from mock import MagicMock
 
 from spacel.aws import ClientCache
@@ -8,6 +9,8 @@ ENCRYPTED_KEY = 'topsecret'
 
 KEY_ARN = ('arn:aws:kms:us-west-2:111111111111111:key/' +
            '1111111-222222-33333-44444-55555555')
+
+CLIENT_ERROR = ClientError({'Error': {'Message': 'Kaboom'}}, 'DescribeKey')
 
 
 class BaseKmsTest(BaseSpaceAppTest):

--- a/src/test/security/__init__.py
+++ b/src/test/security/__init__.py
@@ -1,0 +1,26 @@
+from mock import MagicMock
+
+from spacel.aws import ClientCache
+from test import BaseSpaceAppTest
+
+PLAINTEXT_KEY = '0000000000000000'
+ENCRYPTED_KEY = 'topsecret'
+
+KEY_ARN = ('arn:aws:kms:us-west-2:111111111111111:key/' +
+           '1111111-222222-33333-44444-55555555')
+
+
+class BaseKmsTest(BaseSpaceAppTest):
+    def setUp(self):
+        super(BaseKmsTest, self).setUp()
+        self.kms = MagicMock()
+        self.kms.generate_data_key.return_value = {
+            'Plaintext': PLAINTEXT_KEY,
+            'CiphertextBlob': ENCRYPTED_KEY
+        }
+        self.kms.decrypt.return_value = {
+            'Plaintext': PLAINTEXT_KEY
+        }
+
+        self.clients = MagicMock(spec=ClientCache)
+        self.clients.kms.return_value = self.kms

--- a/src/test/security/test_acm.py
+++ b/src/test/security/test_acm.py
@@ -1,0 +1,73 @@
+from mock import MagicMock
+import unittest
+
+from spacel.aws import ClientCache
+from spacel.security.acm import AcmCertificates
+from test import REGION
+
+TEST_EXAMPLE_COM = '111111'
+STAR_EXAMPLE_COM = '222222'
+STAR_TEST_DOUBLE_COM = '333333'
+STAR_STAR_DOUBLE_COM = '444444'
+
+CERTIFICATE_LIST = [
+    {'DomainName': 'test.example.com', 'CertificateArn': TEST_EXAMPLE_COM},
+    {'DomainName': '*.example.com', 'CertificateArn': STAR_EXAMPLE_COM},
+    {'DomainName': '*.test.double.com', 'CertificateArn': STAR_TEST_DOUBLE_COM},
+    {'DomainName': '*.*.double.com', 'CertificateArn': STAR_STAR_DOUBLE_COM}
+]
+
+
+class TestAcmCertificates(unittest.TestCase):
+    def setUp(self):
+        self.acm = MagicMock()
+        self.clients = MagicMock(spec=ClientCache)
+        self.acm_certs = AcmCertificates(self.clients)
+
+    def test_get_wildcards(self):
+        wildcards = self.acm_certs._get_wildcards('foo.bar.com')
+        self.assertEquals(['*.bar.com'], wildcards)
+
+    def test_get_wildcards_none(self):
+        wildcards = self.acm_certs._get_wildcards('bar.com')
+        self.assertEquals([], wildcards)
+
+    def test_get_wildcards_subdomains(self):
+        wildcards = self.acm_certs._get_wildcards('baz.foo.bar.com')
+        self.assertEquals([
+            '*.foo.bar.com',
+            '*.*.bar.com'
+        ], wildcards)
+
+    def test_get_certificates(self):
+        paginator = MagicMock()
+
+        paginator.paginate.return_value = [{
+            'CertificateSummaryList': CERTIFICATE_LIST
+        }, {
+            'CertificateSummaryList': CERTIFICATE_LIST
+        }]
+        self.acm.get_paginator.return_value = paginator
+
+        certificates = [c for c in self.acm_certs._get_certificates(self.acm)]
+        self.assertEquals(8, len(certificates))
+
+    def test_get_certificate_exact(self):
+        self._mock_certs()
+        cert = self.acm_certs.get_certificate(REGION, 'test.example.com')
+        self.assertEquals(cert, TEST_EXAMPLE_COM)
+
+    def test_get_certificate_wildcard(self):
+        self._mock_certs()
+        cert = self.acm_certs.get_certificate(REGION, 'other.example.com')
+        self.assertEquals(cert, STAR_EXAMPLE_COM)
+
+    def test_get_certificate_best_wildcard(self):
+        self._mock_certs()
+        cert = self.acm_certs.get_certificate(REGION, 'test.test.double.com')
+        # Both STAR_STAR and STAR_TEST will work, we want the most specific:
+        self.assertEquals(cert, STAR_TEST_DOUBLE_COM)
+
+    def _mock_certs(self):
+        self.acm_certs._get_certificates = MagicMock(
+            return_value=CERTIFICATE_LIST)

--- a/src/test/security/test_kms_crypt.py
+++ b/src/test/security/test_kms_crypt.py
@@ -1,6 +1,5 @@
 from botocore.exceptions import ClientError
 from mock import MagicMock
-import unittest
 import six
 
 from spacel.security.kms_crypt import KmsCrypto

--- a/src/test/security/test_kms_crypt.py
+++ b/src/test/security/test_kms_crypt.py
@@ -1,0 +1,66 @@
+from botocore.exceptions import ClientError
+from mock import MagicMock
+import unittest
+import six
+
+from spacel.security.kms_crypt import KmsCrypto
+from spacel.security.kms_key import KmsKeyFactory
+
+from test import REGION
+from test.security import BaseKmsTest, PLAINTEXT_KEY, ENCRYPTED_KEY
+
+
+class TestKmsCrypto(BaseKmsTest):
+    def setUp(self):
+        super(TestKmsCrypto, self).setUp()
+        self.kms_key = MagicMock(spec=KmsKeyFactory)
+        self.kms_crypt = KmsCrypto(self.clients, self.kms_key)
+
+    def test_roundtrip_bytes(self):
+        self._round_trip(six.b('hello world'))
+
+    def test_roundtrip_ascii(self):
+        self._round_trip('hello world')
+
+    def test_roundtrip_utf8(self):
+        self._round_trip(six.u('\u9731'))
+
+    def test_decrypt_invalid(self):
+        # Invalid ciphertext: decrypts to garbage
+        self.assertRaises(ValueError, self.kms_crypt.decrypt,
+                          b'1234567890123456',
+                          b'1234567890123456',
+                          b'1234567890123456',
+                          REGION,
+                          'bytes')
+
+    def test_encrypt_missing_key(self):
+        # GenerateDataKey fails as key doesn't exist, key is created:
+        key_not_found = ClientError({'Error': {
+            'Message': ('An error occurred (NotFoundException) when calling ' +
+                        'the GenerateDataKey operation: Alias ' +
+                        'arn:aws:kms:us-east-1:330658367937:alias/your-alias ' +
+                        'is not found')
+        }}, 'GenerateDataKey')
+        self.kms.generate_data_key.side_effect = [
+            key_not_found,
+            {
+                'Plaintext': PLAINTEXT_KEY,
+                'CiphertextBlob': ENCRYPTED_KEY
+            }
+        ]
+
+        self.kms_crypt.encrypt(self.app, REGION, 'test')
+
+        self.assertEquals(2, self.kms.generate_data_key.call_count)
+        self.kms_key.create_key.assert_called_with(self.app, REGION)
+
+    def _round_trip(self, data):
+        item = self.kms_crypt.encrypt(self.app, REGION, data)
+        self.assertEquals(ENCRYPTED_KEY, item.key)
+        self.assertEquals(REGION, item.key_region)
+
+        decrypted = self.kms_crypt.decrypt_payload(item)
+        self.assertEquals(decrypted, data)
+
+        self.kms_key.create_key.assert_not_called()

--- a/src/test/security/test_kms_key.py
+++ b/src/test/security/test_kms_key.py
@@ -1,9 +1,8 @@
 from botocore.exceptions import ClientError
-from mock import MagicMock
 
 from spacel.security.kms_key import KmsKeyFactory
 from test import REGION
-from test.security import BaseKmsTest, KEY_ARN
+from test.security import BaseKmsTest, KEY_ARN, CLIENT_ERROR
 
 ALIAS = 'alias/test-orbit-test-app'
 KEY_METADATA = {
@@ -12,8 +11,6 @@ KEY_METADATA = {
         'Enabled': True
     }
 }
-
-CLIENT_ERROR = ClientError({'Error': {'Message': 'Kaboom'}}, 'DescribeKey')
 
 
 class TestKmsKeyFactory(BaseKmsTest):

--- a/src/test/security/test_kms_key.py
+++ b/src/test/security/test_kms_key.py
@@ -1,0 +1,86 @@
+from botocore.exceptions import ClientError
+from mock import MagicMock
+
+from spacel.security.kms_key import KmsKeyFactory
+from test import REGION
+from test.security import BaseKmsTest, KEY_ARN
+
+ALIAS = 'alias/test-orbit-test-app'
+KEY_METADATA = {
+    'KeyMetadata': {
+        'Arn': KEY_ARN,
+        'Enabled': True
+    }
+}
+
+CLIENT_ERROR = ClientError({'Error': {'Message': 'Kaboom'}}, 'DescribeKey')
+
+
+class TestKmsKeyFactory(BaseKmsTest):
+    def setUp(self):
+        super(TestKmsKeyFactory, self).setUp()
+        self.kms_factory = KmsKeyFactory(self.clients)
+
+    def test_get_key_alias(self):
+        alias = self.kms_factory.get_key_alias(self.app)
+        self.assertEquals(ALIAS, alias)
+
+    def test_get_key_exists(self):
+        self.kms.describe_key.return_value = KEY_METADATA
+
+        key = self.kms_factory.get_key(self.app, REGION)
+        self.assertEquals(KEY_ARN, key)
+
+        self.kms.describe_key.assert_called_with(KeyId=ALIAS)
+        self.kms.create_key.assert_not_called()
+
+    def test_get_key_exists_disabled(self):
+        key_metadata = KEY_METADATA.copy()
+        key_metadata['KeyMetadata']['Enabled'] = False
+        self.kms.describe_key.return_value = key_metadata
+
+        key = self.kms_factory.get_key(self.app, REGION)
+        self.assertIsNone(key)
+
+        self.kms.describe_key.assert_called_with(KeyId=ALIAS)
+
+    def test_get_key_not_found(self):
+        self.kms.describe_key.side_effect = ClientError({
+            'Error': {
+                'Message': 'Invalid keyId %s' % ALIAS
+            }
+        }, 'DescribeKey')
+
+        self.kms_factory.get_key(self.app, REGION)
+
+        # Key is created:
+        self.kms.create_key.assert_called_once_with()
+
+    def test_get_key_exception(self):
+        self.kms.describe_key.side_effect = CLIENT_ERROR
+
+        self.assertRaises(ClientError, self.kms_factory.get_key,
+                          self.app, REGION)
+
+    def test_create_key(self):
+        self.kms.create_key.return_value = KEY_METADATA
+
+        key = self.kms_factory.create_key(self.app, REGION)
+        self.assertEquals(KEY_ARN, key)
+
+        self.kms.describe_key.assert_not_called()
+        self.kms.create_key.assert_called_once_with()
+        self.kms.create_alias.assert_called_with(AliasName=ALIAS,
+                                                 TargetKeyId=KEY_ARN)
+        self.kms.schedule_key_deletion.assert_not_called()
+
+    def test_create_key_exception(self):
+        self.kms.create_key.return_value = KEY_METADATA
+        self.kms.create_alias.side_effect = CLIENT_ERROR
+
+        self.assertRaises(ClientError, self.kms_factory.create_key,
+                          self.app, REGION)
+        self.kms.schedule_key_deletion.assert_called_with(
+            KeyId=KEY_ARN,
+            PendingWindowInDays=7
+        )

--- a/src/test/security/test_password.py
+++ b/src/test/security/test_password.py
@@ -4,10 +4,11 @@ from spacel.security.kms_crypt import KmsCrypto
 from spacel.security.password import PasswordManager
 from spacel.security.payload import EncryptedPayload
 from test import REGION
-from test.security import BaseKmsTest
+from test.security import BaseKmsTest, CLIENT_ERROR
 
 PASSWORD_LENGTH = 32
 PASSWORD_NAME = 'test-password'
+PASSWORD = 'password'
 
 
 class TestPasswordManager(BaseKmsTest):
@@ -43,6 +44,14 @@ class TestPasswordManager(BaseKmsTest):
         decrypt_func()
         self.kms_crypto.decrypt_payload.assert_called_with(ANY)
 
+    def test_get_password_generate_noop(self):
+        self.dynamodb.get_item.return_value = {}
+        encrypted, decrypt_func = self.password.get_password(self.app, REGION,
+                                                             PASSWORD_NAME,
+                                                             generate=False)
+        self.assertIsNone(encrypted)
+        self.assertIsNone(decrypt_func())
+
     def test_get_password_generate(self):
         self.dynamodb.get_item.return_value = {}
         encrypted, decrypt_func = self.password.get_password(self.app, REGION,
@@ -56,6 +65,29 @@ class TestPasswordManager(BaseKmsTest):
         # Decrypt is never called:
         decrypt_func()
         self.kms_crypto.decrypt_payload.assert_not_called()
+
+    def test_set_password_existing(self):
+        self.dynamodb.get_item.return_value = {
+            'Item': (EncryptedPayload('a', 'b', 'c', REGION, 'utf-8')
+                     .dynamodb_item())
+        }
+        was_set = self.password.set_password(self.app, REGION, PASSWORD_NAME,
+                                             lambda: PASSWORD)
+        self.assertFalse(was_set)
+        self.dynamodb.put_item.assert_not_called()
+
+    def test_set_password(self):
+        self.dynamodb.get_item.return_value = {}
+        was_set = self.password.set_password(self.app, REGION, PASSWORD_NAME,
+                                             lambda: PASSWORD)
+        self.assertTrue(was_set)
+
+    def test_set_password_exception(self):
+        self.dynamodb.get_item.return_value = {}
+        self.dynamodb.put_item.side_effect = CLIENT_ERROR
+        was_set = self.password.set_password(self.app, REGION, PASSWORD_NAME,
+                                             lambda: PASSWORD)
+        self.assertFalse(was_set)
 
     def test_decrypt(self):
         encrypted = MagicMock()

--- a/src/test/security/test_password.py
+++ b/src/test/security/test_password.py
@@ -1,0 +1,63 @@
+from mock import MagicMock, ANY
+
+from spacel.security.kms_crypt import KmsCrypto
+from spacel.security.password import PasswordManager
+from spacel.security.payload import EncryptedPayload
+from test import REGION
+from test.security import BaseKmsTest
+
+PASSWORD_LENGTH = 32
+PASSWORD_NAME = 'test-password'
+
+
+class TestPasswordManager(BaseKmsTest):
+    def setUp(self):
+        super(TestPasswordManager, self).setUp()
+        self.dynamodb = MagicMock()
+        self.clients.dynamodb.return_value = self.dynamodb
+        self.kms_crypto = MagicMock(spec=KmsCrypto)
+        self.password = PasswordManager(self.clients, self.kms_crypto)
+
+    def test_generate_password(self):
+        password = self.password._generate_password(PASSWORD_LENGTH)
+        self.assertEquals(PASSWORD_LENGTH, len(password))
+
+        other_password = self.password._generate_password(PASSWORD_LENGTH)
+        self.assertNotEquals(password, other_password)
+
+    def test_get_password_existing(self):
+        self.dynamodb.get_item.return_value = {
+            'Item': (EncryptedPayload('a', 'b', 'c', REGION, 'utf-8')
+                     .dynamodb_item())
+        }
+
+        encrypted, decrypt_func = self.password.get_password(self.app, REGION,
+                                                             PASSWORD_NAME)
+        self.assertIsInstance(encrypted, EncryptedPayload)
+        self.assertEquals(encrypted.iv, 'a')
+        self.dynamodb.put_item.assert_not_called()
+        self.kms_crypto.encrypt.assert_not_called()
+
+        # Decrypt is deferred until absolutely necessary:
+        self.kms_crypto.decrypt_payload.assert_not_called()
+        decrypt_func()
+        self.kms_crypto.decrypt_payload.assert_called_with(ANY)
+
+    def test_get_password_generate(self):
+        self.dynamodb.get_item.return_value = {}
+        encrypted, decrypt_func = self.password.get_password(self.app, REGION,
+                                                             PASSWORD_NAME)
+
+        self.kms_crypto.encrypt.assert_called_with(self.app, REGION, ANY)
+        self.dynamodb.put_item.assert_called_with(TableName=ANY,
+                                                  Item=ANY,
+                                                  ConditionExpression=ANY)
+
+        # Decrypt is never called:
+        decrypt_func()
+        self.kms_crypto.decrypt_payload.assert_not_called()
+
+    def test_decrypt(self):
+        encrypted = MagicMock()
+        self.password.decrypt(encrypted)
+        self.kms_crypto.decrypt_payload.assert_called_with(encrypted)

--- a/src/test/security/test_payload.py
+++ b/src/test/security/test_payload.py
@@ -1,0 +1,28 @@
+import json
+import unittest
+
+from spacel.security.payload import EncryptedPayload
+from test import REGION
+
+IV = b'0000000000000000'
+CIPHERTEXT = b'0000000000000000'
+KEY = b'0000000000000000'
+ENCODING = 'utf-8'
+
+
+class TestEncryptedPayload(unittest.TestCase):
+    def setUp(self):
+        self.payload = EncryptedPayload(IV, CIPHERTEXT, KEY, REGION, ENCODING)
+
+    def test_roundtrip_dynamodb(self):
+        dynamodb_item = self.payload.dynamodb_item()
+        payload = EncryptedPayload.from_dynamodb_item(dynamodb_item)
+        self.assertEquals(IV, payload.iv)
+        self.assertEquals(CIPHERTEXT, payload.ciphertext)
+        self.assertEquals(KEY, payload.key)
+        self.assertEquals(REGION, payload.key_region)
+        self.assertEquals(ENCODING, payload.encoding)
+
+    def test_json(self):
+        as_json = self.payload.json()
+        json.loads(as_json)

--- a/src/test/security/test_payload.py
+++ b/src/test/security/test_payload.py
@@ -23,6 +23,11 @@ class TestEncryptedPayload(unittest.TestCase):
         self.assertEquals(REGION, payload.key_region)
         self.assertEquals(ENCODING, payload.encoding)
 
-    def test_json(self):
+    def test_roundtrip_json(self):
         as_json = self.payload.json()
-        json.loads(as_json)
+        payload = EncryptedPayload.from_json(as_json)
+        self.assertEquals(IV, payload.iv)
+        self.assertEquals(CIPHERTEXT, payload.ciphertext)
+        self.assertEquals(KEY, payload.key)
+        self.assertEquals(REGION, payload.key_region)
+        self.assertEquals(ENCODING, payload.encoding)


### PR DESCRIPTION
Works like cache integration: the default is a private database, in every deployed region.

Unlike caches:
* RDS is easy to share across regions, so building a "global" database that other regions call back to is possible (not worrying about cross-region replication etc yet).
* RDS requires password authentication, which means a bunch of new code for handling application secrets (KMS encrypted, and decrypted when only necessary).