### PR TITLE
WEBOPS-963: SpotFleet support

### DIFF
--- a/sample/app/http-env-echo-spot.json
+++ b/sample/app/http-env-echo-spot.json
@@ -1,0 +1,28 @@
+{
+  "name": "http-env-echo",
+  "health_check": "HTTP:80/",
+  "spot": {
+    "price": "0.70",
+    "weights": {
+      "c4.large": 1,
+      "c3.large": 1,
+      "m4.large": 1,
+      "m3.large": 1
+    }
+  },
+  "instance_min": 1,
+  "instance_max": 1,
+  "services": {
+    "http-env-echo": {
+      "image": "pwagner/http-env-echo",
+      "ports": {
+        "80": 8080
+      }
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    }
+  }
+}

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -288,6 +288,28 @@
               "Effect": "Allow",
               "Action": "elasticloadbalancing:DescribeInstanceHealth",
               "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+              "Resource": {
+                "Fn::Join": [
+                  "", [
+                    "arn:aws:elasticloadbalancing:",
+                    {"Ref": "AWS::Region"},
+                    ":",
+                    {"Ref": "AWS::AccountId"},
+                    ":loadbalancer/",
+                    {
+                      "Fn::If": [
+                        "ElbPublic",
+                        {"Ref": "PublicElb"},
+                        {"Ref": "PrivateElb"}
+                      ]
+                    }
+                  ]
+                ]
+              }
             }
           ]
         }
@@ -467,7 +489,7 @@
           "Fn::Base64": {
             "Fn::Join": [
               "", [
-                "{\"elb\":\"",
+                "{\"elb\":{\"name\":\"",
                 {
                   "Fn::If": [
                     "ElbPublic",
@@ -475,7 +497,7 @@
                     {"Ref": "PrivateElb"}
                   ]
                 },
-                "\",\"orbit\":\"",
+                "\"},\"orbit\":\"",
                 {"Ref": "Orbit"},
                 "\",\"name\":\"",
                 {"Ref": "Service"},

--- a/src/spacel/cloudformation/vpc.template
+++ b/src/spacel/cloudformation/vpc.template
@@ -345,6 +345,55 @@
         "DBSubnetGroupDescription": "Private RDS subnet group",
         "SubnetIds": [{"Ref": "PrivateRdsSubnet01"}]
       }
+    },
+    "RoleSpotFleet": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "spotfleet.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "RoleSpotFleetPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "root",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeImages",
+                "ec2:DescribeSubnets",
+                "ec2:RequestSpotInstances",
+                "ec2:TerminateInstances",
+                "iam:PassRole"
+              ],
+              "Resource": ["*"]
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "RoleSpotFleet"
+          }
+        ]
+      }
     }
   },
   "Outputs": {
@@ -374,6 +423,9 @@
     },
     "PrivateRdsSubnetGroup": {
       "Value": {"Ref": "PrivateRdsSubnetGroup"}
+    },
+    "RoleSpotFleet": {
+      "Value": {"Fn::GetAtt": ["RoleSpotFleet", "Arn"]}
     }
   }
 }

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -9,9 +9,9 @@ from spacel.provision import (ChangeSetEstimator, CloudProvisioner,
                               LambdaUploader, ProviderOrbitFactory,
                               TemplateUploader)
 
-from spacel.provision.template import (AppTemplate, BastionTemplate,
-                                       IngressResourceFactory, TablesTemplate,
-                                       VpcTemplate)
+from spacel.provision.template import (AppTemplate, AppSpotTemplateDecorator,
+                                       BastionTemplate, IngressResourceFactory,
+                                       TablesTemplate, VpcTemplate)
 from spacel.provision.alarm import AlarmFactory
 from spacel.provision.db import CacheFactory, RdsFactory
 from spacel.security import KmsCrypto, KmsKeyFactory, PasswordManager
@@ -52,9 +52,10 @@ def main(args, in_stream):
 
     # Templates:
     ami_finder = AmiFinder()
+    app_spot = AppSpotTemplateDecorator()
 
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,
-                               rds_factory)
+                               rds_factory, app_spot)
     bastion_template = BastionTemplate(ami_finder)
     tables_template = TablesTemplate()
     vpc_template = VpcTemplate()

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -1,4 +1,5 @@
 import logging
+import six
 
 logger = logging.getLogger('spacel')
 
@@ -51,6 +52,19 @@ class SpaceApp(object):
         self.alarms = params.get('alarms', {})
         self.caches = params.get('caches', {})
         self.databases = params.get('databases', {})
+        self.spot = self._spot(params)
+
+    @staticmethod
+    def _spot(params):
+        spot = params.get('spot')
+        if isinstance(spot, bool) and spot:
+            return {}
+        elif isinstance(spot, six.string_types) and bool(spot):
+            return {}
+        elif isinstance(spot, dict):
+            return spot
+        else:
+            return None
 
     @property
     def full_name(self):

--- a/src/spacel/model/orbit.py
+++ b/src/spacel/model/orbit.py
@@ -46,6 +46,7 @@ class Orbit(object):
         self._private_cache_subnet_groups = {}
         self._private_rds_subnet_groups = {}
         self._public_rds_subnet_groups = {}
+        self._spot_fleet_role = {}
 
         # Output from Bastion:
         self._bastion_eips = defaultdict(dict)
@@ -104,3 +105,6 @@ class Orbit(object):
 
     def public_rds_subnet_group(self, region):
         return self._public_rds_subnet_groups.get(region)
+
+    def spot_fleet_role(self, region):
+        return self._spot_fleet_role.get(region)

--- a/src/spacel/provision/changesets.py
+++ b/src/spacel/provision/changesets.py
@@ -53,6 +53,11 @@ COSTS = {
         'Modify': 10,
         'Remove': 5
     },
+    'AWS::EC2::SpotFleet': {
+        'Add': 30,
+        'Modify': 300,
+        'Remove': 30
+    },
     'AWS::EC2::SubnetRouteTableAssociation': {
         'Add': 5,
         'Remove': 5
@@ -67,15 +72,20 @@ COSTS = {
         'Modify': 30,
         'Remove': 60
     },
-    'AWS::IAM::Role': {
-        'Add': 75,
-        'Modify': 60,
-        'Remove': 75
-    },
     'AWS::IAM::InstanceProfile': {
         'Add': 120,
         'Modify': 60,
         'Remove': 120
+    },
+    'AWS::IAM::Policy': {
+        'Add': 120,
+        'Modify': 60,
+        'Remove': 120
+    },
+    'AWS::IAM::Role': {
+        'Add': 75,
+        'Modify': 60,
+        'Remove': 75
     },
     'AWS::SNS::Topic': {
         'Add': 15,

--- a/src/spacel/provision/orbit/space.py
+++ b/src/spacel/provision/orbit/space.py
@@ -115,6 +115,8 @@ class SpaceElevatorOrbitFactory(BaseCloudFormationFactory):
                 orbit._private_rds_subnet_groups[region] = value
             elif key == 'PrivateCacheSubnetGroup':
                 orbit._private_cache_subnet_groups[region] = value
+            elif key == 'RoleSpotFleet':
+                orbit._spot_fleet_role[region] = value
             elif 'CacheSubnet' in key or 'RdsSubnet' in key:
                 continue
             else:

--- a/src/spacel/provision/provision.py
+++ b/src/spacel/provision/provision.py
@@ -19,7 +19,6 @@ class CloudProvisioner(BaseCloudFormationFactory):
         updates = {}
         for region in app.regions:
             template, secret_params = self._app.app(app, region)
-
             updates[region] = self._stack(app_name, region, template,
                                           secret_parameters=secret_params)
         self._wait_for_updates(app_name, updates)

--- a/src/spacel/provision/template/__init__.py
+++ b/src/spacel/provision/template/__init__.py
@@ -1,4 +1,5 @@
 from .app import AppTemplate
+from .app_spot import AppSpotTemplateDecorator
 from .bastion import BastionTemplate
 from .ingress_resource import IngressResourceFactory
 from .tables import TablesTemplate

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -1,0 +1,114 @@
+import logging
+
+logger = logging.getLogger('spacel.provision.template.app_spot')
+
+ASG_RESOURCES = ('Asg',
+                 'Lc')
+
+GDH_ASG_RESOURCE = ('SpScaleDown',
+                    'SpScaleDown',
+                    'AlarmScaleDown',
+                    'AlarmScaleUp')
+
+
+class AppSpotTemplateDecorator(object):
+    def spotify(self, app, region, template):
+        """
+        Replace ASG with SpotFleet. Literally spot-ify.
+        :return:
+        """
+        if app.spot is None:
+            return
+
+        resources = template['Resources']
+        self._add_spot_fleet(app, region, resources)
+        self._clean_up_asg(template)
+
+    @staticmethod
+    def _add_spot_fleet(app, region, resources):
+        spot_price = app.spot.get('price', '1.00')
+
+
+        # Extract parameters:
+        lc_properties = resources['Lc']['Properties']
+        user_data = lc_properties['UserData']
+        block_mapping = lc_properties['BlockDeviceMappings']
+        monitoring = {'Enabled': lc_properties['InstanceMonitoring']}
+        image_id = lc_properties['ImageId']
+        instance_profile = {
+            'Arn': {
+                'Fn::GetAtt': [lc_properties['IamInstanceProfile']['Ref'],
+                               'Arn']
+            }
+        }
+        security_groups = [
+            {'GroupId': {'Fn::GetAtt': [sg['Ref'], 'GroupId']}}
+            for sg in lc_properties['SecurityGroups']]
+
+        subnets = resources['Asg']['Properties']['VPCZoneIdentifier']
+
+        # Instance weights can be specified
+        weights = app.spot.get('weights')
+        if not weights:
+            weights = {app.instance_type: 1}
+
+        # If we're bidding on a single instance type, prefer AZ saturation
+        # else prefer lowest price.
+        if len(weights) == 1:
+            default_allocation_strat = 'diversified'
+        else:
+            default_allocation_strat = 'lowestPrice'
+        allocation_strat = app.spot.get('strategy', default_allocation_strat)
+
+
+        # Build launch specs:
+        launch_specs = []
+        for weight_type, weight in weights.items():
+            for subnet_id in subnets:
+                launch_specs.append({
+                    'UserData': user_data,
+                    'BlockDeviceMappings': block_mapping,
+                    'IamInstanceProfile': instance_profile,
+                    'InstanceType': weight_type,
+                    'ImageId': image_id,
+                    'Monitoring': monitoring,
+                    'SecurityGroups': security_groups,
+                    'WeightedCapacity': weight,
+                    'SubnetId': subnet_id
+                })
+        logger.debug('Generated %d launch specs.', len(launch_specs))
+
+        # Add spotfleet resource:
+        resources['SpotFleet'] = {
+            'Type': 'AWS::EC2::SpotFleet',
+            'Properties': {
+                'SpotFleetRequestConfigData': {
+                    'AllocationStrategy': allocation_strat,
+                    'IamFleetRole': app.orbit.spot_fleet_role(region),
+                    'SpotPrice': spot_price,
+                    'TargetCapacity': {'Ref': 'InstanceMin'},
+                    'TerminateInstancesWithExpiration': 'true',
+                    'LaunchSpecifications': launch_specs
+                }
+            }
+        }
+
+    @staticmethod
+    def _clean_up_asg(template):
+        resources = template['Resources']
+
+        # Remove any resources that reference the Asg/Lc:
+        for resource in ASG_RESOURCES:
+            resources.pop(resource, None)
+        for gdh_resource in GDH_ASG_RESOURCE:
+            resources.pop(gdh_resource, None)
+
+        # Redirect any outputs that point at the Asg/Lc:
+        outputs = template.get('Outputs', {})
+        for output_name, output_params in outputs.items():
+            output_ref = output_params.get('Value', {}).get('Ref')
+            if output_ref == 'Asg':
+                output_params['Value']['Ref'] = 'SpotFleet'
+        asg_name = outputs.get('AsgName')
+        if asg_name:
+            asg_name['Value']['Ref'] = 'SpotFleet'

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -4,8 +4,10 @@ import unittest
 from spacel.aws import AmiFinder
 from spacel.model import Orbit, SpaceApp, SpaceDockerService
 from spacel.provision.template.app import AppTemplate
+from spacel.provision.template.app_spot import AppSpotTemplateDecorator
 from spacel.provision.alarm import AlarmFactory
 from spacel.provision.db import CacheFactory, RdsFactory
+
 from test.provision.template import SUBNETS
 
 REGION = 'us-east-1'
@@ -18,8 +20,9 @@ class TestAppTemplate(unittest.TestCase):
         self.alarms = MagicMock(spec=AlarmFactory)
         self.caches = MagicMock(spec=CacheFactory)
         self.rds = MagicMock(spec=RdsFactory)
+        self.spot = MagicMock(spec=AppSpotTemplateDecorator)
         self.cache = AppTemplate(self.ami_finder, self.alarms, self.caches,
-                                 self.rds)
+                                 self.rds, self.spot)
         base_template = self.cache.get('elb-service')
         self.base_resources = len(base_template['Resources'])
         self.orbit = Orbit({

--- a/src/test/provision/template/test_app_spot.py
+++ b/src/test/provision/template/test_app_spot.py
@@ -1,0 +1,61 @@
+from spacel.provision.template.app_spot import AppSpotTemplateDecorator
+from spacel.provision.template.base import BaseTemplateCache
+from test import BaseSpaceAppTest, REGION
+
+
+class TestAppSpotTemplateDecorator(BaseSpaceAppTest):
+    def setUp(self):
+        super(TestAppSpotTemplateDecorator, self).setUp()
+        self.resources = {}
+        self.app_spot = AppSpotTemplateDecorator()
+        self.template = BaseTemplateCache().get('elb-service')
+
+    def test_clean_up_asg(self):
+        self.resources['Asg'] = {}
+        self.resources['Lc'] = {}
+        self.resources['AlarmScaleDown'] = {}
+        outputs = {'AsgName': {'Value': {'Ref': 'Asg'}}}
+        template = {
+            'Resources': self.resources,
+            'Outputs': outputs
+        }
+
+        self.app_spot._clean_up_asg(template)
+        self.assertEquals(0, len(self.resources))
+        self.assertEquals('SpotFleet', outputs['AsgName']['Value']['Ref'])
+
+    def test_spotify_noop(self):
+        self.app_spot.spotify(self.app, REGION, self.template)
+        self.assertNotIn('SpotFleet', self.template['Resources'])
+
+    def test_spotify(self):
+        self.app.spot = {}
+
+        self.app_spot.spotify(self.app, REGION, self.template)
+
+        resources = self.template['Resources']
+        fleet_config = (resources['SpotFleet']
+                        ['Properties']
+                        ['SpotFleetRequestConfigData'])
+        self.assertEquals('diversified', fleet_config['AllocationStrategy'])
+        self.assertEquals(1, len(fleet_config['LaunchSpecifications']))
+        self.assertNotIn('Asg', resources)
+        self.assertNotIn('Lc', resources)
+
+    def test_spotify_weights(self):
+        self.app.spot = {
+            'weights': {
+                't2.nano': 1,
+                't2.micro': 2,
+                't2.small': 4
+            }
+        }
+
+        self.app_spot.spotify(self.app, REGION, self.template)
+
+        fleet_config = (self.template['Resources']
+                        ['SpotFleet']
+                        ['Properties']
+                        ['SpotFleetRequestConfigData'])
+        self.assertEquals('lowestPrice', fleet_config['AllocationStrategy'])
+        self.assertEquals(3, len(fleet_config['LaunchSpecifications']))


### PR DESCRIPTION
This is a template decorator that replaces the `Asg` resource with a
`SpotFleet` with the same parameters.

It _should_ work with internal templates too: there's some special code
for cleaning up GDH bits that reference the ASG. (untested).

FleetSpotting: choose 1 c4.xlarge, choose 2 c4.large, choose 4 m4.large, choose life.
 https://www.youtube.com/watch?v=RCxgqHqakXc