### PR TITLE
Finish ACM integration

### DIFF
--- a/sample/app/http-env-echo.json
+++ b/sample/app/http-env-echo.json
@@ -15,6 +15,10 @@
   "public_ports": {
     "80": {
       "sources": ["0.0.0.0/0"]
+    },
+    "443": {
+      "sources": ["0.0.0.0/0"],
+      "internal_port": 80
     }
   }
 }

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -14,7 +14,8 @@ from spacel.provision.template import (AppTemplate, AppSpotTemplateDecorator,
                                        TablesTemplate, VpcTemplate)
 from spacel.provision.alarm import AlarmFactory
 from spacel.provision.db import CacheFactory, RdsFactory
-from spacel.security import KmsCrypto, KmsKeyFactory, PasswordManager
+from spacel.security import (AcmCertificates, KmsCrypto, KmsKeyFactory,
+                             PasswordManager)
 
 
 def main(args, in_stream):
@@ -53,9 +54,10 @@ def main(args, in_stream):
     # Templates:
     ami_finder = AmiFinder()
     app_spot = AppSpotTemplateDecorator()
+    acm = AcmCertificates(clients)
 
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,
-                               rds_factory, app_spot)
+                               rds_factory, app_spot, acm)
     bastion_template = BastionTemplate(ami_finder)
     tables_template = TablesTemplate()
     vpc_template = VpcTemplate()

--- a/src/spacel/model/__init__.py
+++ b/src/spacel/model/__init__.py
@@ -1,2 +1,3 @@
-from .app import SpaceApp, SpaceService, SpaceDockerService
+from .app import SpaceApp, SpaceService, SpaceDockerService, SpaceServicePort
+
 from .orbit import Orbit

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -23,7 +23,7 @@ class SpaceApp(object):
         self.local_health_check = params.get('health_check', 'TCP:80')
 
         public_ports = params.get('public_ports', {80: {}})
-        self.public_ports = {port: SpaceServicePort(port_params)
+        self.public_ports = {port: SpaceServicePort(port, port_params)
                              for port, port_params in public_ports.items()}
 
         self.private_ports = params.get('private_ports', {})
@@ -72,13 +72,21 @@ class SpaceApp(object):
 
 
 class SpaceServicePort(object):
-    def __init__(self, params={}):
-        self.scheme = params.get('scheme', 'HTTP')
-        default_scheme = self.scheme == 'HTTPS' and 'HTTP' or self.scheme
-        self.internal_scheme = params.get('internal_scheme', default_scheme)
+    def __init__(self, port, params={}):
+        self.scheme = params.get('scheme', self._scheme(port))
+
+        self.internal_port = params.get('internal_port', port)
+        self.internal_scheme = params.get('internal_scheme',
+                                          self._scheme(self.internal_port))
 
         self.sources = params.get('sources', ('0.0.0.0/0',))
-        # TODO: HTTPS parameters: cert, ciphers
+        self.certificate = params.get('certificate')
+
+    @staticmethod
+    def _scheme(port):
+        if str(port) == '443':
+            return 'HTTPS'
+        return 'HTTP'
 
 
 class SpaceService(object):

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -5,16 +5,18 @@ from spacel.aws import INSTANCE_VOLUMES
 from spacel.provision import base64_encode
 from spacel.provision.template.base import BaseTemplateCache
 
+SSL_SCHEMES = ('HTTPS', 'SSL')
 
 
 class AppTemplate(BaseTemplateCache):
     def __init__(self, ami_finder, alarm_factory, cache_factory, rds_factory,
-                 spot_decorator):
+                 spot_decorator, acm):
         super(AppTemplate, self).__init__(ami_finder=ami_finder)
         self._alarm_factory = alarm_factory
         self._cache_factory = cache_factory
         self._rds_factory = rds_factory
         self._spot_decorator = spot_decorator
+        self._acm = acm
 
     def app(self, app, region):
         app_template = self.get('elb-service')
@@ -56,8 +58,8 @@ class AppTemplate(BaseTemplateCache):
             params['VirtualHost']['Default'] = app_hostname
         else:
             params['VirtualHostDomain']['Default'] = orbit.domain + '.'
-            generated_dns = '%s-%s.%s' % (app.name, orbit.name, orbit.domain)
-            params['VirtualHost']['Default'] = generated_dns
+            app_hostname = '%s-%s.%s' % (app.name, orbit.name, orbit.domain)
+            params['VirtualHost']['Default'] = app_hostname
 
         # Expand ELB to all AZs:
         public_elb_subnets = orbit.public_elb_subnets(region)
@@ -79,6 +81,7 @@ class AppTemplate(BaseTemplateCache):
         instance_ingress = resources['Sg']['Properties']['SecurityGroupIngress']
         public_elb = resources['PublicElb']['Properties']['Listeners']
         private_elb = resources['PrivateElb']['Properties']['Listeners']
+        elb_ingress_ports = set()
         for port_number, port_config in app.public_ports.items():
             # Allow all sources into ELB:
             for ip_source in port_config.sources:
@@ -90,19 +93,29 @@ class AppTemplate(BaseTemplateCache):
                 })
 
             # Allow ELB->Instance
-            instance_ingress.append({
-                'IpProtocol': 'tcp',
-                'FromPort': port_number,
-                'ToPort': port_number,
-                'SourceSecurityGroupId': {'Ref': 'ElbSg'}
-            })
+            internal_port = port_config.internal_port
+            if internal_port not in elb_ingress_ports:
+                instance_ingress.append({
+                    'IpProtocol': 'tcp',
+                    'FromPort': internal_port,
+                    'ToPort': internal_port,
+                    'SourceSecurityGroupId': {'Ref': 'ElbSg'}
+                })
+                elb_ingress_ports.add(internal_port)
 
             elb_listener = {
-                'InstancePort': port_number,
+                'InstancePort': internal_port,
                 'LoadBalancerPort': port_number,
                 'Protocol': port_config.scheme,
                 'InstanceProtocol': port_config.internal_scheme
             }
+
+            if port_config.scheme in SSL_SCHEMES:
+                cert = port_config.certificate
+                if not cert:
+                    cert = self._acm.get_certificate(region, app_hostname)
+                elb_listener['SSLCertificateId'] = cert
+
             public_elb.append(elb_listener)
             private_elb.append(elb_listener)
 

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import six
 
 from spacel.aws import INSTANCE_VOLUMES
@@ -6,6 +7,8 @@ from spacel.provision import base64_encode
 from spacel.provision.template.base import BaseTemplateCache
 
 SSL_SCHEMES = ('HTTPS', 'SSL')
+
+logger = logging.getLogger('spacel.provision.template.app')
 
 
 class AppTemplate(BaseTemplateCache):
@@ -114,6 +117,12 @@ class AppTemplate(BaseTemplateCache):
                 cert = port_config.certificate
                 if not cert:
                     cert = self._acm.get_certificate(region, app_hostname)
+                if not cert:
+                    logger.warn('Unable to find certificate for %s. ' +
+                                'Specify a "certificate" or provision  in ACM.',
+                                app_hostname)
+                    raise Exception('Public_port %s is missing certificate.' %
+                                    port_number)
                 elb_listener['SSLCertificateId'] = cert
 
             public_elb.append(elb_listener)

--- a/src/spacel/security/__init__.py
+++ b/src/spacel/security/__init__.py
@@ -1,3 +1,4 @@
+from .acm import AcmCertificates
 from .kms_crypt import KmsCrypto, EncryptedPayload
 from .kms_key import KmsKeyFactory
 from .password import PasswordManager

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -10,7 +10,8 @@ REGION = 'us-west-2'
 class BaseSpaceAppTest(unittest.TestCase):
     def setUp(self):
         self.orbit = Orbit({
-            'name': ORBIT_NAME
+            'name': ORBIT_NAME,
+            'domain': 'test.com'
         })
 
         self.app = SpaceApp(self.orbit, {

--- a/src/test/model/test_app.py
+++ b/src/test/model/test_app.py
@@ -33,6 +33,15 @@ class TestSpaceApp(unittest.TestCase):
         self.assertEqual('HTTP', app.public_ports[80].scheme)
         self.assertEquals(('0.0.0.0/0',), app.public_ports[80].sources)
 
+    def test_public_ports_https(self):
+        app = SpaceApp(self.orbit, {
+            'public_ports': {
+                443: {
+                }
+            }
+        })
+        self.assertEqual('HTTPS', app.public_ports[443].scheme)
+
     def test_public_ports_custom_sources(self):
         custom_sources = ('10.0.0.0/8', '192.168.0.0/16')
         app = SpaceApp(self.orbit, {


### PR DESCRIPTION
When the public_port is declared as SSL/HTTPS, use ACM as a fallback if
no specific certificate is given.

Improved handling around port number->scheme mapping: you shouldn't need
to declare that 443 is HTTPS.