### PR TITLE
Spot instances need to set their own tags

### DIFF
--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,8 +2,7 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1",
-    "us-west-2"
+    "us-east-1"
   ],
   "us-west-2": {
     "provider": "gdh",

--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,7 +2,8 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1"
+    "us-east-1",
+    "us-west-2"
   ],
   "us-west-2": {
     "provider": "gdh",

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -332,6 +332,23 @@
         }
       }
     },
+    "TagPolicy": {
+      "DependsOn": "Role",
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "Ec2Tags",
+        "Roles": [{"Ref": "Role"}],
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "ec2:CreateTags",
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    },
     "VolumePolicy": {
       "DependsOn": "Role",
       "Condition": "AddVolumePermissions",

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -489,7 +489,9 @@
           "Fn::Base64": {
             "Fn::Join": [
               "", [
-                "{\"elb\":{\"name\":\"",
+                "{\"tags\": {\"Name\": \"",
+                {"Ref": "AWS::StackName"},
+                "\"},\"elb\":{\"name\":\"",
                 {
                   "Fn::If": [
                     "ElbPublic",

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -489,9 +489,7 @@
           "Fn::Base64": {
             "Fn::Join": [
               "", [
-                "{\"tags\": {\"Name\": \"",
-                {"Ref": "AWS::StackName"},
-                "\"},\"elb\":{\"name\":\"",
+                "{\"elb\":{\"name\":\"",
                 {
                   "Fn::If": [
                     "ElbPublic",

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -193,5 +193,5 @@ class AppTemplate(BaseTemplateCache):
             user_data += ',"systemd":' + json.dumps(systemd)
         if app.volumes:
             params['VolumeSupport']['Default'] = 'true'
-            user_data += ', "volumes":' + json.dumps(app.volumes)
+            user_data += ',"volumes":' + json.dumps(app.volumes)
         return user_data

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -34,10 +34,11 @@ class AppSpotTemplateDecorator(object):
         tags = {
             'Name': {'Ref': 'AWS::StackName'}
         }
-        user_data_param = parameters['UserData']['Default']
+        user_data_param = parameters['UserData']['Default'] or ''
         if user_data_param:
             user_data_param += ','
         user_data_param += '"tags":' + json.dumps(tags)
+        parameters['UserData']['Default'] = user_data_param
 
         # Extract parameters:
         lc_properties = resources['Lc']['Properties']

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -31,9 +31,7 @@ class AppSpotTemplateDecorator(object):
         spot_price = app.spot.get('price', '1.00')
 
         # Set Name tag
-        tags = {
-            'Name': app.full_name
-        }
+        tags = {'Name': app.full_name}
         user_data_param = parameters['UserData']['Default'] or ''
         if user_data_param:
             user_data_param += ','

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 logger = logging.getLogger('spacel.provision.template.app_spot')
 
@@ -21,13 +22,22 @@ class AppSpotTemplateDecorator(object):
             return
 
         resources = template['Resources']
-        self._add_spot_fleet(app, region, resources)
+        parameters = template['Parameters']
+        self._add_spot_fleet(app, region, resources, parameters)
         self._clean_up_asg(template)
 
     @staticmethod
-    def _add_spot_fleet(app, region, resources):
+    def _add_spot_fleet(app, region, resources, parameters):
         spot_price = app.spot.get('price', '1.00')
 
+        # Set Name tag
+        tags = {
+            'Name': {'Ref': 'AWS::StackName'}
+        }
+        user_data_param = parameters['UserData']['Default']
+        if user_data_param:
+            user_data_param += ','
+        user_data_param += '"tags":' + json.dumps(tags)
 
         # Extract parameters:
         lc_properties = resources['Lc']['Properties']

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -71,7 +71,6 @@ class AppSpotTemplateDecorator(object):
             default_allocation_strat = 'lowestPrice'
         allocation_strat = app.spot.get('strategy', default_allocation_strat)
 
-
         # Build launch specs:
         launch_specs = []
         for weight_type, weight in weights.items():

--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -32,7 +32,7 @@ class AppSpotTemplateDecorator(object):
 
         # Set Name tag
         tags = {
-            'Name': {'Ref': 'AWS::StackName'}
+            'Name': app.full_name
         }
         user_data_param = parameters['UserData']['Default'] or ''
         if user_data_param:

--- a/src/test/provision/template/test_app_spot.py
+++ b/src/test/provision/template/test_app_spot.py
@@ -33,6 +33,7 @@ class TestAppSpotTemplateDecorator(BaseSpaceAppTest):
 
         self.app_spot.spotify(self.app, REGION, self.template)
 
+        params = self.template['Parameters']
         resources = self.template['Resources']
         fleet_config = (resources['SpotFleet']
                         ['Properties']
@@ -41,6 +42,7 @@ class TestAppSpotTemplateDecorator(BaseSpaceAppTest):
         self.assertEquals(1, len(fleet_config['LaunchSpecifications']))
         self.assertNotIn('Asg', resources)
         self.assertNotIn('Lc', resources)
+        self.assertIn('"tags":', params['UserData']['Default'])
 
     def test_spotify_weights(self):
         self.app.spot = {


### PR DESCRIPTION
Added support for tags in [spacel-agent](https://github.com/pebble/spacel-agent/pull/21), because spot fleet does not support setting tags.

Deliberated on adding a unique identifier (we use GitDeployIdentifier tag), but followed `spacel-provision` rules (https://github.com/pebble/spacel-provision/blob/master/src/spacel/cloudformation/elb-service.template#L540)

~~Alternatively, this code can/should be moved to `Ref: UserData` to only be included when we use spot?~~ rewritten to go via the `UserData` param so we only feed it when we need to.