### PR TITLE
WEBOPS-963: update SpotFleet GDH cleanup

### DIFF
--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -7,9 +7,10 @@ ASG_RESOURCES = ('Asg',
                  'Lc')
 
 GDH_ASG_RESOURCE = ('SpScaleDown',
-                    'SpScaleDown',
+                    'SpScaleUp',
                     'AlarmScaleDown',
-                    'AlarmScaleUp')
+                    'AlarmScaleUp',
+                    'AlarmContinuousHighLoad')
 
 
 class AppSpotTemplateDecorator(object):


### PR DESCRIPTION
* Duplicated `SpScaleDown`, meant to change to `SpScaleUp`
* Missed `AlarmHighContinuousLoad` altogether