### PR TITLE
TriggerFactory: support decimals

### DIFF
--- a/src/spacel/provision/alarm/trigger/factory.py
+++ b/src/spacel/provision/alarm/trigger/factory.py
@@ -131,13 +131,13 @@ class TriggerFactory(object):
     def _parse_threshold(threshold):
         if not threshold:
             return None, None
-        match = re.match('([=><]+)([0-9]+)', threshold)
+        match = re.match('([=><]+)([0-9.]+)', threshold)
         if not match:
             logger.warn('Invalid threshold %s', threshold)
             return None, None
 
         op = match.group(1)
-        value = int(match.group(2))
+        value = float(match.group(2))
 
         if op == '>':
             return 'GreaterThanThreshold', value

--- a/src/test/provision/alarm/trigger/test_factory.py
+++ b/src/test/provision/alarm/trigger/test_factory.py
@@ -129,6 +129,16 @@ class TestTriggerFactory(unittest.TestCase):
         self.assertEquals(operator, 'LessThanOrEqualToThreshold')
         self.assertEquals(thresh, 200)
 
+    def test_parse_threshold_decimal(self):
+        operator, thresh = self.factory._parse_threshold('<0.3')
+        self.assertEquals(operator, 'LessThanThreshold')
+        self.assertEquals(thresh, 0.3)
+
+    def test_parse_threshold_ignore_garbage_tail(self):
+        operator, thresh = self.factory._parse_threshold('>0.3meow')
+        self.assertEquals(operator, 'GreaterThanThreshold')
+        self.assertEquals(thresh, 0.3)
+
     def test_parse_period_missing(self):
         operator, thresh = self.factory._parse_period(None)
         self.assertIsNone(operator)


### PR DESCRIPTION
That was pretty silly.
Special test case to ensure the added `.` isn't a RegExp wildcard.