### PR TITLE
Skip trying to set parameters if UserData param does not exist

### DIFF
--- a/src/spacel/provision/template/app_spot.py
+++ b/src/spacel/provision/template/app_spot.py
@@ -31,13 +31,14 @@ class AppSpotTemplateDecorator(object):
     def _add_spot_fleet(app, region, resources, parameters):
         spot_price = app.spot.get('price', '1.00')
 
-        # Set Name tag
-        tags = {'Name': app.full_name}
-        user_data_param = parameters['UserData']['Default'] or ''
-        if user_data_param:
-            user_data_param += ','
-        user_data_param += '"tags":' + json.dumps(tags)
-        parameters['UserData']['Default'] = user_data_param
+        if parameters.get('UserData') is not None:
+            # Set Name tag
+            tags = {'Name': app.full_name}
+            user_data_param = parameters['UserData']['Default'] or ''
+            if user_data_param:
+                user_data_param += ','
+            user_data_param += '"tags":' + json.dumps(tags)
+            parameters['UserData']['Default'] = user_data_param
 
         # Extract parameters:
         lc_properties = resources['Lc']['Properties']


### PR DESCRIPTION
Upstream git-deploy-hooks does not have a `UserData` parameter, so this breaks on:

```
remote:   File "/tmp/git-deploy-virtualenv-webops/local/lib/python2.7/site-packages/spacel/provision/template/app_spot.py", line 36, in _add_spot_fleet
remote:     user_data_param = parameters['UserData']['Default'] or ''
remote: KeyError: 'UserData'
```

This check prevents that.