### PR TITLE
Redis integration test

### DIFF
--- a/src/spacel/aws/ami.py
+++ b/src/spacel/aws/ami.py
@@ -8,8 +8,8 @@ logger = logging.getLogger('spacel.aws.ami')
 
 
 class AmiFinder(object):
-    def __init__(self):
-        self._channel = 'stable'
+    def __init__(self, channel='stable'):
+        self._channel = channel
         self._cache = {}
 
     def spacel_ami(self, region):

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -100,12 +100,9 @@ class SpaceService(object):
 
 class SpaceDockerService(SpaceService):
     def __init__(self, name, image, ports=None, volumes=None, environment=None):
-        docker_run_flags = ''
+        docker_run_flags = '--env-file /files/%s.env' % name
         docker_run_flags += SpaceDockerService._dict_flags('p', ports)
         docker_run_flags += SpaceDockerService._dict_flags('v', volumes)
-
-        if environment:
-            docker_run_flags += ' --env-file /files/%s.env' % name
 
         service_name = '%s.service' % name
         unit_file = """[Unit]
@@ -120,7 +117,7 @@ StartLimitInterval=0
 ExecStartPre=-/usr/bin/docker pull {1}
 ExecStartPre=-/usr/bin/docker kill %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStart=/usr/bin/docker run --rm --name %n{2} {1}
+ExecStart=/usr/bin/docker run --rm --name %n {2} {1}
 ExecStop=/usr/bin/docker stop %n
 """.format(name, image, docker_run_flags)
         super(SpaceDockerService, self).__init__(service_name, unit_file,

--- a/src/spacel/provision/db/cache.py
+++ b/src/spacel/provision/db/cache.py
@@ -7,7 +7,7 @@ logger = logging.getLogger('spacel.provision.cache.factory')
 REDIS_PORT = '6379'
 
 # https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html
-REDIS_VERSION = '2.8.24'
+REDIS_VERSION = '3.2.4'
 
 
 class CacheFactory(BaseTemplateDecorator):

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -194,9 +194,9 @@ class AppTemplate(BaseTemplateCache):
                     files['%s.env' % service_name] = {
                         'body': base64_encode(environment_file.encode('utf-8'))
                     }
-            user_data += ',"systemd":' + json.dumps(systemd)
-            user_data += ',"files":' + json.dumps(files)
+            user_data += ',"systemd":' + json.dumps(systemd, sort_keys=True)
+            user_data += ',"files":' + json.dumps(files, sort_keys=True)
         if app.volumes:
             params['VolumeSupport']['Default'] = 'true'
-            user_data += ',"volumes":' + json.dumps(app.volumes)
+            user_data += ',"volumes":' + json.dumps(app.volumes, sort_keys=True)
         return user_data

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -54,7 +54,6 @@ class BaseIntegrationTest(unittest.TestCase):
             'instance_max': 2,
             'services': {
                 'laika': {
-                    'image': self.image(),
                     'ports': {
                         '80': 8080
                     }
@@ -70,12 +69,13 @@ class BaseIntegrationTest(unittest.TestCase):
                 }
             }
         }
+        self.image()
         self.clients = ClientCache()
         self.ssh_db = SpaceSshDb(self.clients)
 
-    @staticmethod
-    def image(version=APP_VERSION):
-        return 'pebbletech/spacel-laika:%s' % version
+    def image(self, version=APP_VERSION):
+        docker_tag = 'pebbletech/spacel-laika:%s' % version
+        self.app_params['services']['laika']['image'] = docker_tag
 
     def orbit(self):
         return Orbit(self.orbit_params)

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -2,6 +2,7 @@ import logging
 import requests
 import uuid
 
+from spacel.provision.db.cache import REDIS_PORT, REDIS_VERSION
 from test_integ import BaseIntegrationTest
 
 logger = logging.getLogger('spacel.test.deploy')
@@ -41,7 +42,7 @@ class TestDeploy(BaseIntegrationTest):
             'redis': {}
         }
         self.provision()
-        # FIXME: _verify_redis
+        self._verify_redis()
 
     def _verify_deploy(self, url=APP_URL, version=None):
         version = version or BaseIntegrationTest.APP_VERSION
@@ -51,3 +52,9 @@ class TestDeploy(BaseIntegrationTest):
     def _verify_message(self, url=APP_URL, message=''):
         r = requests.get('%s/environment' % url)
         self.assertEquals(message, r.json()['message'])
+
+    def _verify_redis(self, url=APP_URL):
+        r = requests.get('%s/redis/info' % url)
+        redis_info = r.json()
+        self.assertEquals(REDIS_PORT, redis_info['tcp_port'])
+        self.assertEquals(REDIS_VERSION, redis_info['redis_version'])

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -22,8 +22,7 @@ class TestDeploy(BaseIntegrationTest):
         """Deploy a HTTPS service, upgrade and verify."""
         self.provision()
 
-        self.app_params['services']['laika']['image'] = \
-            self.image(UPGRADE_VERSION)
+        self.image(UPGRADE_VERSION)
         self.provision()
         self._verify_deploy(version=UPGRADE_VERSION)
 
@@ -36,7 +35,35 @@ class TestDeploy(BaseIntegrationTest):
         self.provision()
         self._verify_message(message=random_message)
 
-    def test_04_cache(self):
+    def test_04_disk(self):
+        # 1 EBS volume, which can only by used by 1 instance at a time:
+        self.app_params['instance_max'] = 1
+        self.app_params['volumes'] = {
+            'data0': {
+                'count': 1,
+                'size': 1
+            }
+        }
+        # Mounted by docker service:
+        self.app_params['services']['laika']['volumes'] = {
+            '/mnt/data0': '/mnt/data'
+        }
+        # Configured by application:
+        self.app_params['services']['laika']['environment'] = {
+            'DISK_PATH': '/mnt/data/file.txt'
+        }
+
+        self.provision()
+
+        initial = self._verify_disk()
+        self.assertNotEquals(0, initial)
+
+        # Upgrade, verify persistence:
+        self.image(UPGRADE_VERSION)
+        self.provision()
+        self._verify_disk(expected_count=initial)
+
+    def test_05_cache(self):
         """Deploy a service with ElastiCache, verify."""
         self.app_params['caches'] = {
             'redis': {}
@@ -58,3 +85,14 @@ class TestDeploy(BaseIntegrationTest):
         redis_info = r.json()
         self.assertEquals(REDIS_PORT, redis_info['tcp_port'])
         self.assertEquals(REDIS_VERSION, redis_info['redis_version'])
+
+    def _verify_disk(self, url=APP_URL, expected_count=0, post_count=10):
+        counter_url = '%s/disk/counter' % url
+        r = requests.get(counter_url)
+        count = r.json()['count']
+        self.assertTrue(count >= expected_count)
+
+        for i in range(post_count):
+            r = requests.post(counter_url)
+            count = r.json()['count']
+        return count


### PR DESCRIPTION
This uses https://github.com/pebble/spacel-agent/pull/25 to integrate
`REDIS_URL` with the hosted laika.

Upgrade Redis version:
https://aws.amazon.com/about-aws/whats-new/2016/10/amazon-elasticache-for-redis-adds-sharding-support-with-redis-cluster/