### PR TITLE
Allow AMI to be fetched from remote URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --update \
     musl-dev \
     python3 \
     python3-dev \
+    ca-certificates \
   && pip3 install -r /app/requirements.txt \
   && apk del \
      gcc \


### PR DESCRIPTION
When attempting to roll out a new app using `pebbletech/spacel-provision` docker, the following output would be returned as soon as it came to fetching the AMI:

```
[REDACTED]
2016-10-30 15:42:14,575 - DEBUG - spacel.aws.ami - AMI manifest https://ami.pbl.io/spacel/stable.json not cached, fetching...
Traceback (most recent call last):
  File "/usr/lib/python3.5/urllib/request.py", line 1254, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
[REDACTED]
  File "/usr/lib/python3.5/ssl.py", line 633, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)

[REDACTED]
  File "/usr/lib/python3.5/urllib/request.py", line 1256, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)>
```

Adding `ca-certificates` allows to continue.

```
2016-10-30 15:46:34,410 - DEBUG - spacel.aws.ami - AMI manifest https://ami.pbl.io/spacel/stable.json not cached, fetching...
2016-10-30 15:46:37,455 - DEBUG - spacel.aws.ami - Found SpaceL AMI ami-df09d5bf in us-west-2
```