### PR TITLE
Bastion DNS aliases

### DIFF
--- a/src/spacel/cloudformation/asg-bastion.template
+++ b/src/spacel/cloudformation/asg-bastion.template
@@ -43,6 +43,18 @@
       "Description": "DNS TLD"
     }
   },
+  "Conditions": {
+    "HasVirtualHost": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {"Ref": "VirtualHostDomain"},
+            ""
+          ]
+        }
+      ]
+    }
+  },
   "Resources": {
     "Sg": {
       "Type": "AWS::EC2::SecurityGroup",
@@ -244,6 +256,7 @@
     },
     "DnsRecord01": {
       "Type": "AWS::Route53::RecordSetGroup",
+      "Condition": "HasVirtualHost",
       "Properties": {
         "HostedZoneName": {"Ref": "VirtualHostDomain"},
         "Comment": "Alias for bastion EIP",

--- a/src/spacel/cloudformation/asg-bastion.template
+++ b/src/spacel/cloudformation/asg-bastion.template
@@ -37,6 +37,10 @@
       "Type": "String",
       "Description": "IP block that can connect to bastion host.",
       "Default": "0.0.0.0/0"
+    },
+    "VirtualHostDomain": {
+      "Type": "String",
+      "Description": "DNS TLD"
     }
   },
   "Resources": {
@@ -236,6 +240,25 @@
       "Type": "AWS::EC2::EIP",
       "Properties": {
         "Domain": "vpc"
+      }
+    },
+    "DnsRecord01": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneName": {"Ref": "VirtualHostDomain"},
+        "Comment": "Alias for bastion EIP",
+        "RecordSets": [
+          {
+            "Name": {
+              "Fn::Join": [
+                ".", [{"Ref": "AWS::Region"}, {"Ref": "Orbit"}, {"Ref": "VirtualHostDomain"}]
+              ]
+            },
+            "Type": "A",
+            "TTL": 300,
+            "ResourceRecords": [{"Ref": "ElasticIp01"}]
+          }
+        ]
       }
     }
   },

--- a/src/spacel/provision/cloudformation.py
+++ b/src/spacel/provision/cloudformation.py
@@ -239,11 +239,11 @@ class BaseCloudFormationFactory(object):
                     status_reason = event.get('ResourceStatusReason', '')
                     if status_reason:
                         status_reason = ' (%s)' % status_reason
-                    logger.info('Resource %s - %s%s at %s',
-                                resource_id,
-                                status,
-                                status_reason,
-                                event_time.strftime('%Y-%m-%d %H:%M:%S'))
+                    logger.debug('Resource %s - %s%s at %s',
+                                 resource_id,
+                                 status,
+                                 status_reason,
+                                 event_time.strftime('%Y-%m-%d %H:%M:%S'))
 
                     # Push "start" to the last logged event
                     if not is_complete:

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -63,7 +63,7 @@ class AppTemplate(BaseTemplateCache):
             domain = '.'.join(domain[-2:]) + '.'
             params['VirtualHostDomain']['Default'] = domain
             params['VirtualHost']['Default'] = app_hostname
-        else:
+        elif orbit.domain:
             params['VirtualHostDomain']['Default'] = orbit.domain + '.'
             app_hostname = '%s-%s.%s' % (app.name, orbit.name, orbit.domain)
             params['VirtualHost']['Default'] = app_hostname

--- a/src/spacel/provision/template/bastion.py
+++ b/src/spacel/provision/template/bastion.py
@@ -23,7 +23,8 @@ class BastionTemplate(BaseTemplateCache):
         # Link to VPC:
         params['VpcId']['Default'] = orbit.vpc_id(region)
         params['Orbit']['Default'] = orbit.name
-        params['VirtualHostDomain']['Default'] = orbit.domain + '.'
+        if orbit.domain:
+            params['VirtualHostDomain']['Default'] = orbit.domain + '.'
 
         # Bastion parameters:
         bastion_type = orbit.get_param(region, BASTION_INSTANCE_TYPE)

--- a/src/spacel/provision/template/bastion.py
+++ b/src/spacel/provision/template/bastion.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from spacel.model.orbit import BASTION_INSTANCE_TYPE, BASTION_INSTANCE_COUNT
 from spacel.provision.template.base import BaseTemplateCache
 
@@ -21,6 +23,7 @@ class BastionTemplate(BaseTemplateCache):
         # Link to VPC:
         params['VpcId']['Default'] = orbit.vpc_id(region)
         params['Orbit']['Default'] = orbit.name
+        params['VirtualHostDomain']['Default'] = orbit.domain + '.'
 
         # Bastion parameters:
         bastion_type = orbit.get_param(region, BASTION_INSTANCE_TYPE)
@@ -45,11 +48,32 @@ class BastionTemplate(BaseTemplateCache):
                         ['Fn::Join'][1][1]
                         ['Fn::Join'][1])
 
+            base_dns = resources['DnsRecord01']
+
+            # Create `bastion01` record for consistency:
+            eip_dns = deepcopy(base_dns)
+            (eip_dns['Properties']
+             ['RecordSets'][0]
+             ['Name']
+             ['Fn::Join'][1]).insert(0, 'bastion01')
+            resources['DnsRecord01Alias'] = eip_dns
+
             for bastion_index in range(2, bastion_count + 1):
                 eip_name = 'ElasticIp%02d' % bastion_index
+                # Add resource, output:
                 resources[eip_name] = eip_resource
                 outputs[eip_name] = {'Value': {'Ref': eip_name}}
+
+                # Append to `eips` list in UserData
                 eip_list.append({'Fn::GetAtt': [eip_name, 'AllocationId']})
+
+                # Add a unique DNS alias:
+                eip_dns = deepcopy(base_dns)
+                dns_recordset = eip_dns['Properties']['RecordSets'][0]
+                dns_label = 'bastion%02d' % bastion_index
+                dns_recordset['Name']['Fn::Join'][1].insert(0, dns_label)
+                dns_recordset['ResourceRecords'][0]['Ref'] = eip_name
+                resources['DnsRecord%02d' % bastion_index] = eip_dns
 
         # Expand ASG to all AZs:
         instance_subnets = orbit.public_instance_subnets(region)

--- a/src/test/provision/template/test_bastion.py
+++ b/src/test/provision/template/test_bastion.py
@@ -1,13 +1,13 @@
-from mock import MagicMock
 import unittest
+
+from mock import MagicMock
 
 from spacel.aws import AmiFinder
 from spacel.model import Orbit
 from spacel.model.orbit import BASTION_INSTANCE_COUNT
 from spacel.provision.template.bastion import BastionTemplate
+from test import REGION
 from test.provision.template import SUBNETS
-
-REGION = 'us-east-1'
 
 
 class TestBastionTemplate(unittest.TestCase):
@@ -30,5 +30,8 @@ class TestBastionTemplate(unittest.TestCase):
 
         bastion = self.cache.bastion(self.orbit, REGION)
 
-        bastion_resources = len(bastion['Resources'])
-        self.assertEquals(self.base_resources + 1, bastion_resources)
+        bastion_resources = bastion['Resources']
+        # 3 resources: Eip01, DNS:bastion01, DNS:bastion02
+        self.assertEquals(self.base_resources + 3, len(bastion_resources))
+        self.assertIn('ElasticIp02', bastion_resources)
+        self.assertIn('DnsRecord02', bastion_resources)


### PR DESCRIPTION
All VPCs get:
* `${region}.${orbit}.${domain}`
* `us-east-1.sl-test.pebbledev.com`

If there's >1 bastion host, aliases are created for each:
* `bastionNN.${region}.${orbit}.${domain}`
* `bastion02.us-east-1.sl-test.pebbledev.com`

Note: in the multi-bastion case, the `01` node has two names.
Round-robin would have been cool, but SSH thinks it looks like DNS
spoofing.

Fixes #35