### PR TITLE
Provide fulltext unit systemd sample/test

### DIFF
--- a/sample/app/laika-systemd.json
+++ b/sample/app/laika-systemd.json
@@ -5,8 +5,11 @@
   "instance_max": 1,
   "services": {
     "laika": {
-      "unit_file": "[Unit]\nRequires=spacel-agent.service\n\n[Service]\nExecStartPre=-/usr/bin/docker pull pebbletech/spacel-laika:latest\nExecStartPre=-/usr/bin/docker kill %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStart=/usr/bin/docker run --rm --name %n -p 80:8080 pebbletech/spacel-laika:latest\nExecStop=/usr/bin/docker stop %n"
+      "unit_file": "[Unit]\nRequires=spacel-agent.service\n\n[Service]\nExecStartPre=-/usr/bin/docker pull pebbletech/spacel-laika:latest\nExecStartPre=-/usr/bin/docker kill %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStart=/usr/bin/docker run --rm --name %n -p 80:8080 --env-file=/files/test.env pebbletech/spacel-laika:latest\nExecStop=/usr/bin/docker stop %n"
     }
+  },
+  "files": {
+    "test.env": "MESSAGE=i am a file"
   },
   "public_ports": {
     "80": {

--- a/sample/app/laika-systemd.json
+++ b/sample/app/laika-systemd.json
@@ -1,0 +1,16 @@
+{
+  "name": "laika",
+  "health_check": "HTTP:80/",
+  "instance_min": 1,
+  "instance_max": 1,
+  "services": {
+    "laika": {
+      "unit_file": "[Unit]\nRequires=spacel-agent.service\n\n[Service]\nExecStartPre=-/usr/bin/docker pull pebbletech/spacel-laika:latest\nExecStartPre=-/usr/bin/docker kill %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStart=/usr/bin/docker run --rm --name %n -p 80:8080 pebbletech/spacel-laika:latest\nExecStop=/usr/bin/docker stop %n"
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    }
+  }
+}

--- a/sample/orbit/sl-test.json
+++ b/sample/orbit/sl-test.json
@@ -1,0 +1,7 @@
+{
+  "name": "sl-test",
+  "domain": "pebbledev.com",
+  "regions": [
+    "us-east-1"
+  ]
+}

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -1,5 +1,6 @@
 import logging
 import six
+from spacel.provision import base64_encode
 
 logger = logging.getLogger('spacel')
 
@@ -52,6 +53,16 @@ class SpaceApp(object):
                 continue
 
             logger.warning('Invalid service: %s', service_name)
+
+        self.files = {}
+        files = params.get('files', {})
+        for file_name, file_params in files.items():
+            if isinstance(file_params, six.string_types):
+                encoded_body = base64_encode(file_params.encode('utf-8'))
+                self.files[file_name] = {'body': encoded_body}
+            else:
+                self.files[file_name] = file_params
+
         self.alarms = params.get('alarms', {})
         self.caches = params.get('caches', {})
         self.databases = params.get('databases', {})

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import six
 from spacel.provision import base64_encode
 
@@ -113,7 +114,8 @@ class SpaceService(object):
 
 class SpaceDockerService(SpaceService):
     def __init__(self, name, image, ports=None, volumes=None, environment=None):
-        docker_run_flags = '--env-file /files/%s.env' % name
+        name_base = os.path.splitext(name)[0]
+        docker_run_flags = '--env-file /files/%s.env' % name_base
         docker_run_flags += SpaceDockerService._dict_flags('p', ports)
         docker_run_flags += SpaceDockerService._dict_flags('v', volumes)
 

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -33,6 +33,8 @@ class SpaceApp(object):
         self.services = {}
         services = params.get('services', {})
         for service_name, service_params in services.items():
+            if '.' not in service_name:
+                service_name += '.service'
             service_env = service_params.get('environment', {})
             unit_file = service_params.get('unit_file')
             if unit_file:
@@ -104,7 +106,6 @@ class SpaceDockerService(SpaceService):
         docker_run_flags += SpaceDockerService._dict_flags('p', ports)
         docker_run_flags += SpaceDockerService._dict_flags('v', volumes)
 
-        service_name = '%s.service' % name
         unit_file = """[Unit]
 Description={0}
 Requires=spacel-agent.service
@@ -120,8 +121,7 @@ ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n {2} {1}
 ExecStop=/usr/bin/docker stop %n
 """.format(name, image, docker_run_flags)
-        super(SpaceDockerService, self).__init__(service_name, unit_file,
-                                                 environment)
+        super(SpaceDockerService, self).__init__(name, unit_file, environment)
 
     @staticmethod
     def _dict_flags(flag, items):

--- a/src/spacel/provision/changesets.py
+++ b/src/spacel/provision/changesets.py
@@ -67,6 +67,11 @@ COSTS = {
         'Modify': 5,
         'Remove': 5
     },
+    'AWS::ElasticLoadBalancing::LoadBalancer': {
+        'Add': 15,
+        'Modify': 5,
+        'Remove': 5
+    },
     'AWS::ElastiCache::ReplicationGroup': {
         'Add': 120,
         'Modify': 30,
@@ -91,6 +96,11 @@ COSTS = {
         'Add': 300,
         'Modify': 300,
         'Remove': 120
+    },
+    'AWS::Route53::RecordSetGroup': {
+        'Add': 5,
+        'Modify': 5,
+        'Remove': 5
     },
     'AWS::SNS::Topic': {
         'Add': 15,

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -178,10 +178,9 @@ class AppTemplate(BaseTemplateCache):
 
     @staticmethod
     def _user_data(params, app):
-        user_data = ''
+        systemd = {}
+        files = {}
         if app.services:
-            systemd = {}
-            files = {}
             for service_name, service in app.services.items():
                 unit_file = service.unit_file.encode('utf-8')
                 systemd[service.name] = {
@@ -194,8 +193,15 @@ class AppTemplate(BaseTemplateCache):
                     files['%s.env' % service_name] = {
                         'body': base64_encode(environment_file.encode('utf-8'))
                     }
+
+        files.update(app.files)
+
+        user_data = ''
+        if systemd:
             user_data += ',"systemd":' + json.dumps(systemd, sort_keys=True)
+        if files:
             user_data += ',"files":' + json.dumps(files, sort_keys=True)
+
         if app.volumes:
             params['VolumeSupport']['Default'] = 'true'
             user_data += ',"volumes":' + json.dumps(app.volumes, sort_keys=True)

--- a/src/test/model/test_app.py
+++ b/src/test/model/test_app.py
@@ -5,7 +5,7 @@ from spacel.model.app import SpaceApp, SpaceDockerService
 
 ORBIT_REGIONS = ('us-east-1', 'us-west-2')
 CONTAINER = 'pwagner/elasticsearch-aws'
-SERVICE_NAME = 'elasticsearch'
+SERVICE_NAME = 'elasticsearch.service'
 
 
 class TestSpaceApp(unittest.TestCase):

--- a/src/test/model/test_app.py
+++ b/src/test/model/test_app.py
@@ -89,7 +89,7 @@ class TestSpaceApp(unittest.TestCase):
                 SERVICE_NAME: {}
             }
         })
-        
+
         self.assertEqual(0, len(app.services))
 
     def test_spot(self):
@@ -105,6 +105,44 @@ class TestSpaceApp(unittest.TestCase):
     def test_full_name(self):
         app = SpaceApp(self.orbit, {})
         self.assertEquals(app.full_name, 'test-orbit-test')
+
+    def test_files_raw_string(self):
+        app = SpaceApp(self.orbit, {
+            'files': {
+                'test-file': 'meow'
+            }
+        })
+
+        self.assertEquals(1, len(app.files))
+        self.assertEquals({'body': 'bWVvdw=='}, app.files['test-file'])
+
+    def test_files_raw_encoded(self):
+        encoded_body = {'body': 'bWVvdw=='}
+        app = SpaceApp(self.orbit, {
+            'files': {
+                'test-file': encoded_body
+            }
+        })
+
+        self.assertEquals(1, len(app.files))
+        self.assertEquals(encoded_body, app.files['test-file'])
+
+    def test_files_encrypted(self):
+        encrypted_payload = {
+            'iv': '',
+            'key': '',
+            'key_region': '',
+            'ciphertext': '',
+            'encoding': ''
+        }
+        app = SpaceApp(self.orbit, {
+            'files': {
+                'test-file': encrypted_payload
+            }
+        })
+
+        self.assertEquals(1, len(app.files))
+        self.assertEquals(encrypted_payload, app.files['test-file'])
 
 
 class TestSpaceDockerService(unittest.TestCase):

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -152,7 +152,7 @@ class TestAppTemplate(BaseSpaceAppTest):
     def test_user_data_services(self):
         params = {'VolumeSupport': {}}
         self.app.services = {
-            'test.service': SpaceDockerService('test', 'test/test',
+            'test.service': SpaceDockerService('test.service', 'test/test',
                                                environment={'FOO': 'bar'})
         }
 

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -1,5 +1,7 @@
-import unittest
 import logging
+import unittest
+
+import requests
 
 from spacel.aws import ClientCache
 from spacel.main import provision
@@ -24,6 +26,8 @@ class BaseIntegrationTest(unittest.TestCase):
     APP_DOMAIN = 'pebbledev.com'
     APP_HOSTNAME = '%s-%s.%s' % (APP_NAME, ORBIT_NAME, APP_DOMAIN)
     APP_VERSION = '0.1.0'
+    UPGRADE_VERSION = '0.0.2'
+    APP_URL = 'https://%s' % APP_HOSTNAME
 
     @classmethod
     def setUpClass(cls):
@@ -91,3 +95,8 @@ class BaseIntegrationTest(unittest.TestCase):
             self.ssh_db.add_key(app.orbit, user, key)
             self.ssh_db.grant(app, user)
         return app
+
+    @staticmethod
+    def _get(url):
+        full_url = '%s/%s' % (BaseIntegrationTest.APP_URL, url)
+        return requests.get(full_url)

--- a/src/test_integ/test_persistence.py
+++ b/src/test_integ/test_persistence.py
@@ -1,0 +1,72 @@
+import requests
+
+from spacel.provision.db.cache import REDIS_PORT, REDIS_VERSION
+from test_integ import BaseIntegrationTest
+
+
+class TestDeployPersistence(BaseIntegrationTest):
+    def test_01_disk(self):
+        """Deploy a service with persistent EBS volume, verify."""
+        # 1 EBS volume, which can only by used by 1 instance at a time:
+        self.app_params['instance_max'] = 1
+        self.app_params['volumes'] = {
+            'data0': {
+                'count': 1,
+                'size': 1
+            }
+        }
+        # Mounted by docker service:
+        self.app_params['services']['laika']['volumes'] = {
+            '/mnt/data0': '/mnt/data'
+        }
+        # Configured by application:
+        self.app_params['services']['laika']['environment'] = {
+            'DISK_PATH': '/mnt/data/file.txt'
+        }
+
+        self.provision()
+
+        initial = self._verify_disk()
+        self.assertNotEquals(0, initial)
+
+        # Upgrade, verify persistence:
+        self.image(BaseIntegrationTest.UPGRADE_VERSION)
+        self.provision()
+        self._verify_disk(expected_count=initial)
+
+    def test_02_cache(self):
+        """Deploy a service with ElastiCache, verify."""
+        self.app_params['caches'] = {
+            'redis': {}
+        }
+        self.provision()
+        self._verify_redis()
+
+    def test_03_rds(self):
+        """Deploy a service with RDS, verify."""
+        self.app_params['databases'] = {
+            'postgres': {}
+        }
+        self.provision()
+        # FIXME: verify_rds
+
+    def _verify_redis(self):
+        r = requests.get('%s/redis/info' % BaseIntegrationTest.APP_URL)
+        redis_info = r.json()
+        self.assertEquals(REDIS_PORT, redis_info['tcp_port'])
+        self.assertEquals(REDIS_VERSION, redis_info['redis_version'])
+        counter_url = '%s/redis/counter' % BaseIntegrationTest.APP_URL
+        self._verify_counter(counter_url, post_count=10)
+
+    def _verify_disk(self, expected_count=0, post_count=10):
+        counter_url = '%s/disk/counter' % BaseIntegrationTest.APP_URL
+        return self._verify_counter(counter_url, expected_count, post_count)
+
+    def _verify_counter(self, counter_url, expected_count=0, post_count=10):
+        r = requests.get(counter_url)
+        count = r.json()['count']
+        self.assertTrue(count >= expected_count)
+        for i in range(post_count):
+            r = requests.post(counter_url)
+            count = r.json()['count']
+        return count


### PR DESCRIPTION
Our artisinal systemd units are handcrafted to order.

Migrating where `foo` -> `foo.service` correction takes place for
consistency with generated docker units.

Splitting persistence integration tests out from regular old deployment.

Fixes #37