### PR TITLE
Make ELB not required

### DIFF
--- a/sample/app/http-env-echo-no-loadbalancer.json
+++ b/sample/app/http-env-echo-no-loadbalancer.json
@@ -4,7 +4,7 @@
   "instance_min": 1,
   "instance_max": 1,
   "loadbalancer": false,
-  "availability": "public",
+  "instance_availability": "internet-facing",
   "services": {
     "http-env-echo": {
       "image": "pwagner/http-env-echo",

--- a/sample/app/http-env-echo-no-loadbalancer.json
+++ b/sample/app/http-env-echo-no-loadbalancer.json
@@ -3,7 +3,7 @@
   "instance_type": "t2.nano",
   "instance_min": 1,
   "instance_max": 1,
-  "loadbalancer": false,
+  "elb_availability": "disabled",
   "instance_availability": "internet-facing",
   "services": {
     "http-env-echo": {

--- a/sample/app/http-env-echo-no-loadbalancer.json
+++ b/sample/app/http-env-echo-no-loadbalancer.json
@@ -1,0 +1,21 @@
+{
+  "name": "http-env-echo",
+  "instance_type": "t2.nano",
+  "instance_min": 1,
+  "instance_max": 1,
+  "loadbalancer": false,
+  "availability": "public",
+  "services": {
+    "http-env-echo": {
+      "image": "pwagner/http-env-echo",
+      "ports": {
+        "80": 8080
+      }
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    }
+  }
+}

--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,7 +2,8 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1"
+    "us-east-1",
+    "us-west-2"
   ],
   "us-east-1": {
     "bastion_instance_count": 0

--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,9 +2,11 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1",
-    "us-west-2"
+    "us-east-1"
   ],
+  "us-east-1": {
+    "bastion_instance_count": 0
+  },
   "us-west-2": {
     "provider": "gdh",
     "parent_stack": "git-deploy",

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -30,6 +30,10 @@
       "Type": "AWS::EC2::Subnet::Id",
       "Description": "First private subnet for instances."
     },
+    "PublicInstanceSubnet01": {
+      "Type": "AWS::EC2::Subnet::Id",
+      "Description": "First public subnet for instances."
+    },
     "ElbScheme": {
       "Description": "Scheme for ELB",
       "Type": "String",

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -33,7 +33,8 @@
     "ElbScheme": {
       "Description": "Scheme for ELB",
       "Type": "String",
-      "Default": "internet-facing"
+      "Default": "disabled",
+      "AllowedValues": ["internet-facing", "internal", "disabled"]
     },
     "HealthCheckTarget": {
       "Description": "Target for HealthCheck.",
@@ -113,14 +114,10 @@
         "internal"
       ]
     },
-    "HasElb": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {"Ref": "ElbScheme"},
-            ""
-          ]
-        }
+    "ElbDisabled": {
+      "Fn::Equals": [
+        {"Ref": "ElbScheme"},
+        "disabled"
       ]
     },
     "AddVolumePermissions": {
@@ -543,7 +540,7 @@
             "Fn::Join": [
               "", [
                 { "Fn::If": [
-                  "HasElb",
+                  "ElbDisabled",
                   {"Fn::Join": [
                     "", [
                       "{\"elb\":{\"name\":\"",
@@ -639,7 +636,7 @@
     "Elb": {
       "Value": {
         "Fn::If": [
-          "HasElb",
+          "ElbDisabled",
           {"Fn::If": [
             "ElbPublic",
             {"Ref": "PublicElb"},

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -33,8 +33,7 @@
     "ElbScheme": {
       "Description": "Scheme for ELB",
       "Type": "String",
-      "Default": "internet-facing",
-      "AllowedValues": ["internet-facing", "internal"]
+      "Default": "internet-facing"
     },
     "HealthCheckTarget": {
       "Description": "Target for HealthCheck.",
@@ -112,6 +111,16 @@
       "Fn::Equals": [
         {"Ref": "ElbScheme"},
         "internal"
+      ]
+    },
+    "HasElb": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {"Ref": "ElbScheme"},
+            ""
+          ]
+        }
       ]
     },
     "AddVolumePermissions": {
@@ -533,15 +542,24 @@
           "Fn::Base64": {
             "Fn::Join": [
               "", [
-                "{\"elb\":{\"name\":\"",
-                {
-                  "Fn::If": [
-                    "ElbPublic",
-                    {"Ref": "PublicElb"},
-                    {"Ref": "PrivateElb"}
-                  ]
-                },
-                "\"},\"orbit\":\"",
+                { "Fn::If": [
+                  "HasElb",
+                  {"Fn::Join": [
+                    "", [
+                      "{\"elb\":{\"name\":\"",
+                      {
+                        "Fn::If": [
+                          "ElbPublic",
+                          {"Ref": "PublicElb"},
+                          {"Ref": "PrivateElb"}
+                        ]
+                      },
+                      "\"},"
+                    ]
+                  ]},
+                  "{"
+                ]},
+                "\"orbit\":\"",
                 {"Ref": "Orbit"},
                 "\",\"name\":\"",
                 {"Ref": "Service"},
@@ -621,9 +639,13 @@
     "Elb": {
       "Value": {
         "Fn::If": [
-          "ElbPublic",
-          {"Ref": "PublicElb"},
-          {"Ref": "PrivateElb"}
+          "HasElb",
+          {"Fn::If": [
+            "ElbPublic",
+            {"Ref": "PublicElb"},
+            {"Ref": "PrivateElb"}
+          ]},
+          ""
         ]
       }
     }

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -545,6 +545,7 @@
               "", [
                 { "Fn::If": [
                   "ElbDisabled",
+                  "{",
                   {"Fn::Join": [
                     "", [
                       "{\"elb\":{\"name\":\"",
@@ -557,8 +558,7 @@
                       },
                       "\"},"
                     ]
-                  ]},
-                  "{"
+                  ]}
                 ]},
                 "\"orbit\":\"",
                 {"Ref": "Orbit"},
@@ -642,12 +642,12 @@
       "Value": {
         "Fn::If": [
           "ElbDisabled",
+          "",
           {"Fn::If": [
             "ElbPublic",
             {"Ref": "PublicElb"},
             {"Ref": "PrivateElb"}
-          ]},
-          ""
+          ]}
         ]
       }
     }

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -52,7 +52,7 @@ def provision(app):
     cache_factory = CacheFactory(ingress_factory)
     rds_factory = RdsFactory(clients, ingress_factory, password_manager)
     # Templates:
-    ami_finder = AmiFinder()
+    ami_finder = AmiFinder('latest')
     app_spot = AppSpotTemplateDecorator()
     acm = AcmCertificates(clients)
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -52,7 +52,7 @@ def provision(app):
     cache_factory = CacheFactory(ingress_factory)
     rds_factory = RdsFactory(clients, ingress_factory, password_manager)
     # Templates:
-    ami_finder = AmiFinder('latest')
+    ami_finder = AmiFinder()
     app_spot = AppSpotTemplateDecorator()
     acm = AcmCertificates(clients)
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -21,11 +21,17 @@ class SpaceApp(object):
         self.instance_type = params.get('instance_type', 't2.nano')
         self.instance_min = params.get('instance_min', 1)
         self.instance_max = params.get('instance_max', 2)
-        self.scheme = params.get('scheme', 'internet-facing')
         self.health_check = params.get('health_check', 'TCP:80')
         self.local_health_check = params.get('health_check', 'TCP:80')
         self.loadbalancer = self._str2bool(params.get('loadbalancer', 'true'))
-        self.availability = params.get('availability', 'private')
+
+        self.instance_scheme = params.get('instance_scheme', 'private')
+        self.instance_availability = params.get('instance_availability',
+                                                self.instance_scheme)
+
+        self.elb_scheme = params.get('elb_scheme', 'internet-facing')
+        self.elb_availability = params.get('elb_availability', self.elb_scheme)
+        self.scheme = params.get('scheme', self.elb_availability)
 
         public_ports = params.get('public_ports', {80: {}})
         self.public_ports = {port: SpaceServicePort(port, port_params)

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -24,7 +24,7 @@ class SpaceApp(object):
         self.scheme = params.get('scheme', 'internet-facing')
         self.health_check = params.get('health_check', 'TCP:80')
         self.local_health_check = params.get('health_check', 'TCP:80')
-        self.loadbalancer = params.get('loadbalancer', 'true')
+        self.loadbalancer = self._str2bool(params.get('loadbalancer', 'true'))
         self.availability = params.get('availability', 'private')
 
         public_ports = params.get('public_ports', {80: {}})
@@ -82,6 +82,10 @@ class SpaceApp(object):
             return spot
         else:
             return None
+
+    @staticmethod
+    def _str2bool(v):
+        return str(v).lower() in ('yes', 'true', '1')
 
     @property
     def full_name(self):

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -23,15 +23,12 @@ class SpaceApp(object):
         self.instance_max = params.get('instance_max', 2)
         self.health_check = params.get('health_check', 'TCP:80')
         self.local_health_check = params.get('health_check', 'TCP:80')
-        self.loadbalancer = self._str2bool(params.get('loadbalancer', 'true'))
 
-        self.instance_scheme = params.get('instance_scheme', 'private')
         self.instance_availability = params.get('instance_availability',
-                                                self.instance_scheme)
-
-        self.elb_scheme = params.get('elb_scheme', 'internet-facing')
-        self.elb_availability = params.get('elb_availability', self.elb_scheme)
-        self.scheme = params.get('scheme', self.elb_availability)
+                                                'private')
+        self.elb_availability = params.get('elb_availability',
+                                           'internet-facing')
+        self.loadbalancer = self.elb_availability != 'disabled'
 
         public_ports = params.get('public_ports', {80: {}})
         self.public_ports = {port: SpaceServicePort(port, port_params)
@@ -88,10 +85,6 @@ class SpaceApp(object):
             return spot
         else:
             return None
-
-    @staticmethod
-    def _str2bool(v):
-        return str(v).lower() in ('yes', 'true', '1')
 
     @property
     def full_name(self):

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -24,6 +24,8 @@ class SpaceApp(object):
         self.scheme = params.get('scheme', 'internet-facing')
         self.health_check = params.get('health_check', 'TCP:80')
         self.local_health_check = params.get('health_check', 'TCP:80')
+        self.loadbalancer = params.get('loadbalancer', 'true')
+        self.availability = params.get('availability', 'private')
 
         public_ports = params.get('public_ports', {80: {}})
         self.public_ports = {port: SpaceServicePort(port, port_params)

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -73,7 +73,7 @@ class AppTemplate(BaseTemplateCache):
             app_hostname = '%s-%s.%s' % (app.name, orbit.name, orbit.domain)
             params['VirtualHost']['Default'] = app_hostname
 
-        if app.loadbalancer == 'true':
+        if app.loadbalancer:
             params['ElbScheme']['Default'] = app.scheme
             # Expand ELB to all AZs:
             public_elb_subnets = orbit.public_elb_subnets(region)
@@ -107,7 +107,7 @@ class AppTemplate(BaseTemplateCache):
         private_elb = resources['PrivateElb']['Properties']['Listeners']
         elb_ingress_ports = set()
         for port_number, port_config in sorted(app.public_ports.items()):
-            if app.loadbalancer != 'true':
+            if not app.loadbalancer:
                 for ip_source in port_config.sources:
                     instance_ingress.append({
                         'IpProtocol': 'tcp',
@@ -196,7 +196,7 @@ class AppTemplate(BaseTemplateCache):
                 })
 
         # Clean up loadbalancer if it's unwanted
-        if app.loadbalancer != 'true':
+        if not app.loadbalancer:
             params['PublicElb'] = {
                 'Type': 'String',
                 'Default': False
@@ -211,7 +211,7 @@ class AppTemplate(BaseTemplateCache):
                  resources['ElbHealthPolicy'],
                  resources['Asg']['Properties']['LoadBalancerNames'])
             resources['Asg']['Properties']['HealthCheckType'] = 'EC2'
-            params['ElbScheme']['Default'] = ''
+            params['ElbScheme']['Default'] = 'disabled'
 
         self._alarm_factory.add_alarms(app_template, app.alarms)
         self._cache_factory.add_caches(app, region, app_template, app.caches)

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -50,7 +50,6 @@ class AppTemplate(BaseTemplateCache):
             params['PrivateRdsSubnetGroup']['Default'] = private_rds_group
 
         # Inject parameters:
-        params['ElbScheme']['Default'] = app.scheme
         params['HealthCheckTarget']['Default'] = app.health_check
         params['InstanceType']['Default'] = app.instance_type
         params['InstanceMin']['Default'] = app.instance_min
@@ -74,20 +73,32 @@ class AppTemplate(BaseTemplateCache):
             app_hostname = '%s-%s.%s' % (app.name, orbit.name, orbit.domain)
             params['VirtualHost']['Default'] = app_hostname
 
-        # Expand ELB to all AZs:
-        public_elb_subnets = orbit.public_elb_subnets(region)
-        private_elb_subnets = orbit.private_elb_subnets(region)
-        self._subnet_params(params, 'PublicElb', public_elb_subnets)
-        self._subnet_params(params, 'PrivateElb', private_elb_subnets)
+        if app.loadbalancer == 'true':
+            params['ElbScheme']['Default'] = app.scheme
+            # Expand ELB to all AZs:
+            public_elb_subnets = orbit.public_elb_subnets(region)
+            private_elb_subnets = orbit.private_elb_subnets(region)
+            self._subnet_params(params, 'PublicElb', public_elb_subnets)
+            self._subnet_params(params, 'PrivateElb', private_elb_subnets)
 
-        self._elb_subnets(resources, 'PublicElb', public_elb_subnets)
-        self._elb_subnets(resources, 'PrivateElb', private_elb_subnets)
+            self._elb_subnets(resources, 'PublicElb', public_elb_subnets)
+            self._elb_subnets(resources, 'PrivateElb', private_elb_subnets)
 
         # Expand ASG to all AZs:
-        private_instance_subnets = orbit.private_instance_subnets(region)
-        self._subnet_params(params, 'PrivateInstance', private_instance_subnets)
-        self._asg_subnets(resources, 'PrivateInstance',
-                          private_instance_subnets)
+        if app.availability == 'public':
+            public_instance_subnets = orbit.public_instance_subnets(region)
+            self._subnet_params(params, 'PrivateInstance',
+                                public_instance_subnets)
+            self._asg_subnets(resources, 'PrivateInstance',
+                              public_instance_subnets)
+            # There is no other means of getting internet (out) otherwise!
+            resources['Lc']['Properties']['AssociatePublicIpAddress'] = True
+        else:
+            private_instance_subnets = orbit.private_instance_subnets(region)
+            self._subnet_params(params, 'PrivateInstance',
+                                private_instance_subnets)
+            self._asg_subnets(resources, 'PrivateInstance',
+                              private_instance_subnets)
 
         # Public ports:
         elb_ingress = resources['ElbSg']['Properties']['SecurityGroupIngress']
@@ -96,47 +107,58 @@ class AppTemplate(BaseTemplateCache):
         private_elb = resources['PrivateElb']['Properties']['Listeners']
         elb_ingress_ports = set()
         for port_number, port_config in sorted(app.public_ports.items()):
-            # Allow all sources into ELB:
-            for ip_source in port_config.sources:
-                elb_ingress.append({
-                    'IpProtocol': 'tcp',
-                    'FromPort': port_number,
-                    'ToPort': port_number,
-                    'CidrIp': ip_source
-                })
+            if app.loadbalancer != 'true':
+                for ip_source in port_config.sources:
+                    instance_ingress.append({
+                        'IpProtocol': 'tcp',
+                        'FromPort': port_number,
+                        'ToPort': port_number,
+                        'CidrIp': ip_source
+                    })
+            else:
+                # Allow all sources into ELB:
+                for ip_source in port_config.sources:
+                    elb_ingress.append({
+                        'IpProtocol': 'tcp',
+                        'FromPort': port_number,
+                        'ToPort': port_number,
+                        'CidrIp': ip_source
+                    })
 
-            # Allow ELB->Instance
-            internal_port = port_config.internal_port
-            if internal_port not in elb_ingress_ports:
-                instance_ingress.append({
-                    'IpProtocol': 'tcp',
-                    'FromPort': internal_port,
-                    'ToPort': internal_port,
-                    'SourceSecurityGroupId': {'Ref': 'ElbSg'}
-                })
-                elb_ingress_ports.add(internal_port)
+                # Allow ELB->Instance
+                internal_port = port_config.internal_port
+                if internal_port not in elb_ingress_ports:
+                    instance_ingress.append({
+                        'IpProtocol': 'tcp',
+                        'FromPort': internal_port,
+                        'ToPort': internal_port,
+                        'SourceSecurityGroupId': {'Ref': 'ElbSg'}
+                    })
+                    elb_ingress_ports.add(internal_port)
 
-            elb_listener = {
-                'InstancePort': str(internal_port),
-                'LoadBalancerPort': port_number,
-                'Protocol': port_config.scheme,
-                'InstanceProtocol': port_config.internal_scheme
-            }
+                elb_listener = {
+                    'InstancePort': str(internal_port),
+                    'LoadBalancerPort': port_number,
+                    'Protocol': port_config.scheme,
+                    'InstanceProtocol': port_config.internal_scheme
+                }
 
-            if port_config.scheme in SSL_SCHEMES:
-                cert = port_config.certificate
-                if not cert:
-                    cert = self._acm.get_certificate(region, app_hostname)
-                if not cert:
-                    logger.warning('Unable to find certificate for %s. ' +
-                                   'Specify a "certificate" or request in ACM.',
-                                   app_hostname)
-                    raise Exception('Public_port %s is missing certificate.' %
-                                    port_number)
-                elb_listener['SSLCertificateId'] = cert
+                if port_config.scheme in SSL_SCHEMES:
+                    cert = port_config.certificate
+                    if not cert:
+                        cert = self._acm.get_certificate(region, app_hostname)
+                    if not cert:
+                        logger.warning(
+                            'Unable to find certificate for %s. ' +
+                            'Specify a "certificate" or request in ACM.',
+                            app_hostname)
+                        raise Exception(
+                            'Public_port %s is missing certificate.' %
+                            port_number)
+                    elb_listener['SSLCertificateId'] = cert
 
-            public_elb.append(elb_listener)
-            private_elb.append(elb_listener)
+                public_elb.append(elb_listener)
+                private_elb.append(elb_listener)
 
         # Private ports:
         for private_port, protocols in sorted(app.private_ports.items()):
@@ -172,6 +194,24 @@ class AppTemplate(BaseTemplateCache):
                     'DeviceName': device,
                     'VirtualName': 'ephemeral%d' % volume_index
                 })
+
+        # Clean up loadbalancer if it's unwanted
+        if app.loadbalancer != 'true':
+            params['PublicElb'] = {
+                'Type': 'String',
+                'Default': False
+            }
+            params['PrivateElb'] = {
+                'Type': 'String',
+                'Default': False
+            }
+            del params['PrivateElbSubnet01'], params['PublicElbSubnet01']
+            del (resources['PublicElb'], resources['PrivateElb'],
+                 resources['ElbSg'], resources['DnsRecord'],
+                 resources['ElbHealthPolicy'],
+                 resources['Asg']['Properties']['LoadBalancerNames'])
+            resources['Asg']['Properties']['HealthCheckType'] = 'EC2'
+            params['ElbScheme']['Default'] = ''
 
         self._alarm_factory.add_alarms(app_template, app.alarms)
         self._cache_factory.add_caches(app, region, app_template, app.caches)

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -97,6 +97,9 @@ class AppTemplate(BaseTemplateCache):
                 app.instance_availability == 'multi-region':
             self._asg_subnets(resources, 'PublicInstance',
                               public_instance_subnets)
+            resources['Asg']['Properties']['VPCZoneIdentifier'][0] = {
+                'Ref': 'PublicInstanceSubnet01'
+            }
             # There is no other means of getting internet (out) otherwise!
             resources['Lc']['Properties']['AssociatePublicIpAddress'] = True
         else:

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -87,18 +87,19 @@ class AppTemplate(BaseTemplateCache):
             self._elb_subnets(resources, 'PrivateElb', private_elb_subnets)
 
         # Expand ASG to all AZs:
-        if app.availability == 'public':
-            public_instance_subnets = orbit.public_instance_subnets(region)
-            self._subnet_params(params, 'PrivateInstance',
-                                public_instance_subnets)
-            self._asg_subnets(resources, 'PrivateInstance',
+        public_instance_subnets = orbit.public_instance_subnets(region)
+        self._subnet_params(params, 'PublicInstance',
+                            public_instance_subnets)
+        private_instance_subnets = orbit.private_instance_subnets(region)
+        self._subnet_params(params, 'PrivateInstance',
+                            private_instance_subnets)
+        if app.instance_availability == 'internet-facing' or \
+                app.instance_availability == 'multi-region':
+            self._asg_subnets(resources, 'PublicInstance',
                               public_instance_subnets)
             # There is no other means of getting internet (out) otherwise!
             resources['Lc']['Properties']['AssociatePublicIpAddress'] = True
         else:
-            private_instance_subnets = orbit.private_instance_subnets(region)
-            self._subnet_params(params, 'PrivateInstance',
-                                private_instance_subnets)
             self._asg_subnets(resources, 'PrivateInstance',
                               private_instance_subnets)
 

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -76,7 +76,7 @@ class AppTemplate(BaseTemplateCache):
             params['VirtualHost']['Default'] = app_hostname
 
         if app.loadbalancer:
-            params['ElbScheme']['Default'] = app.scheme
+            params['ElbScheme']['Default'] = app.elb_availability
             # Expand ELB to all AZs:
             public_elb_subnets = orbit.public_elb_subnets(region)
             private_elb_subnets = orbit.private_elb_subnets(region)

--- a/src/spacel/security/kms_key.py
+++ b/src/spacel/security/kms_key.py
@@ -39,7 +39,8 @@ class KmsKeyFactory(object):
             return key_arn
         except ClientError as e:
             e_message = e.response['Error'].get('Message', '')
-            if 'Invalid keyId' not in e_message:
+            if 'Invalid keyId' not in e_message and \
+                    'is not found' not in e_message:
                 raise e
 
         if create:

--- a/src/test/model/test_app.py
+++ b/src/test/model/test_app.py
@@ -157,6 +157,25 @@ class TestSpaceApp(unittest.TestCase):
         self.assertEquals(1, len(app.files))
         self.assertEquals(encrypted_payload, app.files['test-file'])
 
+    def test_str2bool(self):
+        app = SpaceApp(self.orbit, {'loadbalancer': False})
+        self.assertEqual(False, app.loadbalancer)
+
+        app = SpaceApp(self.orbit, {'loadbalancer': True})
+        self.assertEqual(True, app.loadbalancer)
+
+        app = SpaceApp(self.orbit, {'loadbalancer': 'false'})
+        self.assertEqual(False, app.loadbalancer)
+
+        app = SpaceApp(self.orbit, {'loadbalancer': 'true'})
+        self.assertEqual(True, app.loadbalancer)
+
+        app = SpaceApp(self.orbit, {'loadbalancer': 1})
+        self.assertEqual(True, app.loadbalancer)
+
+        app = SpaceApp(self.orbit, {'loadbalancer': 0})
+        self.assertEqual(False, app.loadbalancer)
+
 
 class TestSpaceDockerService(unittest.TestCase):
     def test_constructor_ports(self):

--- a/src/test/model/test_app.py
+++ b/src/test/model/test_app.py
@@ -119,6 +119,10 @@ class TestSpaceApp(unittest.TestCase):
         app = SpaceApp(self.orbit, {})
         self.assertEquals(app.full_name, 'test-orbit-test')
 
+    def test_no_elb(self):
+        app = SpaceApp(self.orbit, {'elb_availability': 'disabled'})
+        self.assertEqual(False, app.loadbalancer)
+
     def test_files_raw_string(self):
         app = SpaceApp(self.orbit, {
             'files': {
@@ -156,25 +160,6 @@ class TestSpaceApp(unittest.TestCase):
 
         self.assertEquals(1, len(app.files))
         self.assertEquals(encrypted_payload, app.files['test-file'])
-
-    def test_str2bool(self):
-        app = SpaceApp(self.orbit, {'loadbalancer': False})
-        self.assertEqual(False, app.loadbalancer)
-
-        app = SpaceApp(self.orbit, {'loadbalancer': True})
-        self.assertEqual(True, app.loadbalancer)
-
-        app = SpaceApp(self.orbit, {'loadbalancer': 'false'})
-        self.assertEqual(False, app.loadbalancer)
-
-        app = SpaceApp(self.orbit, {'loadbalancer': 'true'})
-        self.assertEqual(True, app.loadbalancer)
-
-        app = SpaceApp(self.orbit, {'loadbalancer': 1})
-        self.assertEqual(True, app.loadbalancer)
-
-        app = SpaceApp(self.orbit, {'loadbalancer': 0})
-        self.assertEqual(False, app.loadbalancer)
 
 
 class TestSpaceDockerService(unittest.TestCase):

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -64,6 +64,37 @@ class TestAppTemplate(BaseSpaceAppTest):
         bastion_sg_param = app['Parameters']['BastionSecurityGroup']['Default']
         self.assertEqual('sg-123tes', bastion_sg_param)
 
+    def test_app_availability(self):
+        self.app.availability = 'public'
+        self.orbit.public_instance_subnets = MagicMock(return_value=('test',))
+
+        app, _ = self.cache.app(self.app, REGION)
+
+        self.orbit.public_instance_subnets.assert_called_once()
+        public_addr = (app['Resources']['Lc']['Properties']
+                          ['AssociatePublicIpAddress'])
+        self.assertEqual(True, public_addr)
+
+    def test_app_no_loadbalancer(self):
+        self.app.loadbalancer = 'false'
+
+        app, _ = self.cache.app(self.app, REGION)
+
+        self.assertEqual(False, app['Parameters']['PublicElb']['Default'])
+        self.assertEqual(False, app['Parameters']['PrivateElb']['Default'])
+        self.assertNotIn('PublicElb', app['Resources'])
+        self.assertNotIn('PrivateElb', app['Resources'])
+        self.assertNotIn('ElbSg', app['Resources'])
+        self.assertNotIn('DnsRecord', app['Resources'])
+        self.assertNotIn('ElbHealthPolicy', app['Resources'])
+        self.assertNotIn('LoadBalancerNames', app['Resources']['Asg']
+                                                 ['Properties'])
+        self.assertNotIn('PrivateElbSubnet01', app['Parameters'])
+        self.assertNotIn('PublicElbSubnet01', app['Parameters'])
+        self.assertEqual('', app['Parameters']['ElbScheme']['Default'])
+        self.assertEqual('EC2', app['Resources']['Asg']['Properties']
+                                   ['HealthCheckType'])
+
     def test_app_private_ports(self):
         self.app.private_ports = {123: ['TCP']}
 

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -33,6 +33,7 @@ class TestAppTemplate(BaseSpaceAppTest):
         self.orbit._public_elb_subnets = {REGION: SUBNETS}
         self.orbit._private_elb_subnets = {REGION: SUBNETS}
         self.orbit._private_instance_subnets = {REGION: SUBNETS}
+        self.orbit._public_instance_subnets = {REGION: SUBNETS}
 
     def test_app(self):
         app, _ = self.cache.app(self.app, REGION)
@@ -67,7 +68,7 @@ class TestAppTemplate(BaseSpaceAppTest):
         self.assertEqual('sg-123tes', bastion_sg_param)
 
     def test_app_availability(self):
-        self.app.availability = 'public'
+        self.app.instance_availability = 'internet-facing'
         self.orbit.public_instance_subnets = MagicMock(return_value=('test',))
 
         app, _ = self.cache.app(self.app, REGION)

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -76,7 +76,7 @@ class TestAppTemplate(BaseSpaceAppTest):
         self.assertEqual(True, public_addr)
 
     def test_app_no_loadbalancer(self):
-        self.app.loadbalancer = 'false'
+        self.app.loadbalancer = False
 
         app, _ = self.cache.app(self.app, REGION)
 
@@ -91,7 +91,7 @@ class TestAppTemplate(BaseSpaceAppTest):
                                                  ['Properties'])
         self.assertNotIn('PrivateElbSubnet01', app['Parameters'])
         self.assertNotIn('PublicElbSubnet01', app['Parameters'])
-        self.assertEqual('', app['Parameters']['ElbScheme']['Default'])
+        self.assertEqual('disabled', app['Parameters']['ElbScheme']['Default'])
         self.assertEqual('EC2', app['Resources']['Asg']['Properties']
                                    ['HealthCheckType'])
 


### PR DESCRIPTION
- Set `"loadbalancer": "false"` to skip creating a loadbalancer
- Set `"availability": "public"` to create instances in a public subnet, and to give them a public IP address (prelude to #45, #50 comes to mind)

tested on develop ✅ 

Fixes #47