### PR TITLE
Integration test failures

### DIFF
--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -606,7 +606,8 @@
         "AutoScalingRollingUpdate": {
           "MinInstancesInService": {"Ref": "InstanceMinInService"},
           "WaitOnResourceSignals": "true",
-          "PauseTime": "PT10M"
+          "PauseTime": "PT10M",
+          "SuspendProcesses": ["ReplaceUnhealthy"]
         }
       }
     },

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -68,7 +68,8 @@ def provision(app):
     orbit_factory.get_orbit(app.orbit)
     provisioner = CloudProvisioner(clients, change_sets, template_up,
                                    app_template)
-    provisioner.app(app)
+    if not provisioner.app(app):
+        return 1
     return 0
 
 

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -121,7 +121,7 @@ class SpaceDockerService(SpaceService):
 
         unit_file = """[Unit]
 Description={0}
-Requires=spacel-agent.service
+Wants=spacel-agent.service
 
 [Service]
 User=space
@@ -129,10 +129,9 @@ TimeoutStartSec=0
 Restart=always
 StartLimitInterval=0
 ExecStartPre=-/usr/bin/docker pull {1}
-ExecStartPre=-/usr/bin/docker kill %n
-ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=-/usr/bin/docker rm -f %n
 ExecStart=/usr/bin/docker run --rm --name %n {2} {1}
-ExecStop=/usr/bin/docker stop %n
+ExecStop=/usr/bin/docker stop -t 2 %n
 """.format(name, image, docker_run_flags)
         super(SpaceDockerService, self).__init__(name, unit_file, environment)
 

--- a/src/spacel/provision/provision.py
+++ b/src/spacel/provision/provision.py
@@ -14,6 +14,7 @@ class CloudProvisioner(BaseCloudFormationFactory):
         """
         Provision an app in all regions.
         :param app:  App to provision.
+        :returns True if updates completed.
         """
         app_name = app.full_name
         updates = {}
@@ -21,7 +22,7 @@ class CloudProvisioner(BaseCloudFormationFactory):
             template, secret_params = self._app.app(app, region)
             updates[region] = self._stack(app_name, region, template,
                                           secret_parameters=secret_params)
-        self._wait_for_updates(app_name, updates)
+        return self._wait_for_updates(app_name, updates)
 
     def delete_app(self, app):
         """

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -37,7 +37,6 @@ class BaseIntegrationTest(unittest.TestCase):
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
         logging.getLogger('paramiko').setLevel(logging.CRITICAL)
         logging.getLogger('requests').setLevel(logging.CRITICAL)
-
         logging.getLogger('spacel').setLevel(logging.DEBUG)
 
     def setUp(self):
@@ -100,3 +99,7 @@ class BaseIntegrationTest(unittest.TestCase):
     def _get(url):
         full_url = '%s/%s' % (BaseIntegrationTest.APP_URL, url)
         return requests.get(full_url)
+
+    def _set_unit_file(self, unit_file):
+        del self.app_params['services']['laika']['image']
+        self.app_params['services']['laika']['unit_file'] = unit_file

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -1,9 +1,6 @@
-import logging
 import uuid
 
 from test_integ import BaseIntegrationTest
-
-logger = logging.getLogger('spacel.test.deploy')
 
 
 class TestDeploy(BaseIntegrationTest):
@@ -32,8 +29,7 @@ class TestDeploy(BaseIntegrationTest):
 
     def test_04_systemd(self):
         """Deploy a service with fulltext systemd unit."""
-        del self.app_params['services']['laika']['image']
-        self.app_params['services']['laika']['unit_file'] = '''[Unit]
+        self._set_unit_file('''[Unit]
 Description=Fulltext unit
 Requires=spacel-agent.service
 
@@ -47,7 +43,7 @@ ExecStartPre=-/usr/bin/docker kill %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n -p 80:8080 -e MESSAGE=handwritten {0}
 ExecStop=/usr/bin/docker stop %n
-'''.format('pebbletech/spacel-laika:latest')
+'''.format('pebbletech/spacel-laika:latest'))
 
         self.provision()
         self._verify_message('handwritten')

--- a/src/test_integ/test_failure.py
+++ b/src/test_integ/test_failure.py
@@ -1,0 +1,24 @@
+from test_integ import BaseIntegrationTest
+
+
+class TestDeployFailure(BaseIntegrationTest):
+    def setUp(self):
+        super(TestDeployFailure, self).setUp()
+        self.provision()
+
+    def test_unit_does_not_load(self):
+        """Bad syntax means unit file won't load."""
+        self._set_unit_file('meow')
+        self.provision(expected=1)
+
+    def test_unit_does_not_start(self):
+        """Valid unit file that fails to start."""
+        self._set_unit_file('''[Service]
+ExecStart=/bin/false
+''')
+        self.provision(expected=1)
+
+    def test_fail_elb_health_check(self):
+        """Docker unit doesn't expose port, so ELB can't verify."""
+        del self.app_params['services']['laika']['ports']
+        self.provision(expected=1)


### PR DESCRIPTION
* Refactor wait_for_updates to detect any CF stacks that rollback
* Suspend `ReplaceUnhealthy` during `UpdatePolicy`; otherwise the
defaults have the ASG recycling instances (600s) while instances are
waiting to be healthy in the Elb (900s).
* Refactor templated units to `Wants=spacel-agent` instead of
`Requires=`; this prevents downstream units automatically restarting
when spacel-agent is restarted (noticed spacel-agent never sees running
units while testing https://github.com/pebble/spacel-agent/pull/38 )