### PR TITLE
WEBOPS-945: integration test per-entry decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Environment Variables:
 * `TEMPLATE_REGION` Region of `TEMPLATE_BUCKET` (if not specified, `LAMBDA_REGION` is used).
 * `WEBHOOKS_PAGERDUTY` Default endpoint for PagerDuty notifications: should use PagerDuty [CloudWatch Integration](https://www.pagerduty.com/docs/guides/aws-cloudwatch-integration-guide/)
 * `PAGERDUTY_API_KEY` API key for PagerDuty, for auto-registering PagerDuty services when applications are added.
+* `SPACEL_AGENT_CHANNEL` Channel of [spacel-agent AMI](https://github.com/pebble/vz-spacel-agent) to use. This can be `stable` (default) or `latest`.
 
 
 ## Architecture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       - LAMBDA_BUCKET=spacel-pebbledev
       - LAMBDA_REGION=us-east-1
+      - SPACEL_AGENT_CHANNEL=latest
     env_file: .env
     entrypoint:
       - sh

--- a/src/spacel/aws/ami.py
+++ b/src/spacel/aws/ami.py
@@ -8,8 +8,8 @@ logger = logging.getLogger('spacel.aws.ami')
 
 
 class AmiFinder(object):
-    def __init__(self, channel='stable'):
-        self._channel = channel
+    def __init__(self, channel=None):
+        self._channel = channel or 'stable'
         self._cache = {}
 
     def spacel_ami(self, region):

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -53,7 +53,8 @@ def provision(app):
     cache_factory = CacheFactory(ingress_factory)
     rds_factory = RdsFactory(clients, ingress_factory, password_manager)
     # Templates:
-    ami_finder = AmiFinder()
+    ami_channel = os.environ.get('SPACEL_AGENT_CHANNEL')
+    ami_finder = AmiFinder(ami_channel)
     app_spot = AppSpotTemplateDecorator()
     acm = AcmCertificates(clients)
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -27,7 +27,7 @@ ORBIT_REGIONS = ['us-east-1']
 class BaseIntegrationTest(unittest.TestCase):
     APP_DOMAIN = 'pebbledev.com'
     APP_HOSTNAME = '%s-%s.%s' % (APP_NAME, ORBIT_NAME, APP_DOMAIN)
-    APP_VERSION = '0.1.0'
+    APP_VERSION = '0.1.1'
     UPGRADE_VERSION = '0.0.2'
     APP_URL = 'https://%s' % APP_HOSTNAME
 

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 from test_integ import BaseIntegrationTest
@@ -61,6 +62,14 @@ ExecStop=/usr/bin/docker stop %n
     def test_05_encrypted_file(self):
         """Encrypted file is decrypted."""
         self.app_params['files'] = {'laika.env': ENCRYPTED_ENV}
+        self.provision()
+        self._verify_message('top secret')
+
+    def test_06_encrypted_entry(self):
+        """Encrypted file is decrypted."""
+        self.app_params['files'] = {
+            'laika.env': 'MESSAGE=%s' % json.dumps(ENCRYPTED_ENV)
+        }
         self.provision()
         self._verify_message('top secret')
 


### PR DESCRIPTION
- Accept `SPACEL_AGENT_CHANNEL` environment parameter for toggling
  between `latest` and `stable` AMIs. (avoiding `AMI` in this variable, as the ability to pull a `docker container/tag` may be handy while working on `spacel-agent` changes? (AMI packaging is slow!)
- Now src/test_integ/* can be executed with a `latest` AMI to verify it
  before promoting to `stable`; neato!

- Prefer `0.1.1` for tests instead of `0.1.0`; version injection botched
  the `0.1.0` build on DockerHub so it doesn't return the expected
  version!