### PR TITLE
WEBOPS-565: Verify RDS integration

### DIFF
--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -54,7 +54,8 @@ def provision(app):
     rds_factory = RdsFactory(clients, ingress_factory, password_manager)
     # Templates:
     ami_channel = os.environ.get('SPACEL_AGENT_CHANNEL')
-    ami_finder = AmiFinder(ami_channel)
+    ami_cache = os.environ.get('SPACEL_AGENT_CACHE_BUST') == 'true'
+    ami_finder = AmiFinder(ami_channel, cache_bust=ami_cache)
     app_spot = AppSpotTemplateDecorator()
     acm = AcmCertificates(clients)
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,

--- a/src/test/aws/test_ami.py
+++ b/src/test/aws/test_ami.py
@@ -1,7 +1,8 @@
-from io import BytesIO
 import json
-from mock import MagicMock, patch
 import unittest
+from io import BytesIO
+
+from mock import MagicMock, patch
 
 from spacel.aws.ami import AmiFinder
 
@@ -37,9 +38,19 @@ class TestAmiFinder(unittest.TestCase):
 
         self.assertEqual(1, mock_urlopen.call_count)
 
+    @patch('spacel.aws.ami.urlopen')
+    def test_ami_found_cache_bust(self, mock_urlopen):
+        self.ami_finder.cache_bust = True
+        self._mock_response(mock_urlopen)
+
+        self.ami_finder.spacel_ami(REGION)
+        self.ami_finder.spacel_ami(REGION)
+
+        self.assertEqual(2, mock_urlopen.call_count)
+
     @staticmethod
     def _mock_response(mock_urlopen):
         response_bytes = json.dumps({
             REGION: AMI
         }).encode('utf-8')
-        mock_urlopen.return_value = BytesIO(response_bytes)
+        mock_urlopen.side_effect = lambda x: BytesIO(response_bytes)

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -102,6 +102,11 @@ class BaseIntegrationTest(unittest.TestCase):
         full_url = '%s/%s' % (BaseIntegrationTest.APP_URL, url)
         return requests.get(full_url)
 
+    @staticmethod
+    def _post(url):
+        full_url = '%s/%s' % (BaseIntegrationTest.APP_URL, url)
+        return requests.post(full_url)
+
     def _set_unit_file(self, unit_file):
         del self.app_params['services']['laika']['image']
         self.app_params['services']['laika']['unit_file'] = unit_file


### PR DESCRIPTION
Teach AmiFinder how to skip local+CloudFront cache: implementing this is
faster than waiting for the AMI with https://github.com/pebble/spacel-agent/pull/28 to land :P