### PR TITLE
Feature flag: disable NAT gateway

### DIFF
--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -6,7 +6,8 @@
     "us-west-2"
   ],
   "us-east-1": {
-    "bastion_instance_count": 0
+    "bastion_instance_count": 0,
+    "private_nat_gateway": "disabled"
   },
   "us-west-2": {
     "provider": "gdh",

--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,8 +2,7 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1",
-    "us-west-2"
+    "us-east-1"
   ],
   "us-east-1": {
     "bastion_instance_count": 0,

--- a/src/spacel/model/orbit.py
+++ b/src/spacel/model/orbit.py
@@ -8,6 +8,7 @@ DEFAULTS = 'defaults'
 NAME = 'name'
 DOMAIN = 'domain'
 PRIVATE_NETWORK = 'private_network'
+PRIVATE_NAT_GATEWAY = 'private_nat_gateway'
 
 BASTION_INSTANCE_COUNT = 'bastion_instance_count'
 BASTION_INSTANCE_TYPE = 'bastion_instance_type'
@@ -23,6 +24,7 @@ GDH_DEPLOY = 'deploy_stack'
 class Orbit(object):
     DEFAULT_VALUES = {
         PRIVATE_NETWORK: '192.168',
+        PRIVATE_NAT_GATEWAY: 'enabled',
         BASTION_INSTANCE_COUNT: 1,
         BASTION_INSTANCE_TYPE: 't2.nano',
         BASTION_SOURCE: '0.0.0.0/0',

--- a/src/spacel/provision/app/space.py
+++ b/src/spacel/provision/app/space.py
@@ -21,6 +21,10 @@ class SpaceElevatorAppFactory(BaseCloudFormationFactory):
         updates = {}
         for region in app.regions:
             template, secret_params = self._app_template.app(app, region)
+            if not template and not secret_params:
+                logger.warn('App %s will not be updated, invalid syntax!',
+                            app_name)
+                continue
             updates[region] = self._stack(app_name, region, template,
                                           secret_parameters=secret_params)
         return self._wait_for_updates(app_name, updates)

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -4,6 +4,7 @@ import logging
 import six
 
 from spacel.aws import INSTANCE_VOLUMES
+from spacel.model.orbit import PRIVATE_NAT_GATEWAY
 from spacel.provision import base64_encode
 from spacel.provision.template.base import BaseTemplateCache
 
@@ -103,6 +104,15 @@ class AppTemplate(BaseTemplateCache):
             # There is no other means of getting internet (out) otherwise!
             resources['Lc']['Properties']['AssociatePublicIpAddress'] = True
         else:
+            private_nat_gateway = orbit.get_param(
+                region, PRIVATE_NAT_GATEWAY) == 'enabled'
+            if not private_nat_gateway:
+                logger.error('"private_nat_gateway" has been disabled in' +
+                             ' orbit.json, availability "private" is not' +
+                             ' possible while the nat gateway has been' +
+                             ' disabled!')
+                return False, False
+
             self._asg_subnets(resources, 'PrivateInstance',
                               private_instance_subnets)
 

--- a/src/spacel/provision/template/vpc.py
+++ b/src/spacel/provision/template/vpc.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from spacel.model.orbit import NAT_PER_AZ, PRIVATE_NETWORK
+from spacel.model.orbit import NAT_PER_AZ, PRIVATE_NETWORK, PRIVATE_NAT_GATEWAY
 from spacel.provision.template.base import BaseTemplateCache
 
 
@@ -31,6 +31,9 @@ class VpcTemplate(BaseTemplateCache):
 
         base_az = params['Az01']
         base_az['Default'] = azs[0]
+
+        private_nat_gateway = orbit.get_param(
+            region, PRIVATE_NAT_GATEWAY) == 'enabled'
 
         base_nat_eip = resources['NatEip01']
         base_nat_gateway = resources['NatGateway01']
@@ -75,36 +78,43 @@ class VpcTemplate(BaseTemplateCache):
             self._add_subnet(resources, outputs, az_index, az_param,
                              'PrivateRds', 180 + az_index, private_rt_resource)
 
-            # Each AZ _can_ have a NAT gateway:
-            nat_eip_clone = deepcopy(base_nat_eip)
-            nat_eip_clone['Condition'] = 'MultiAzNat'
-            nat_eip_resource = 'NatEip%02d' % az_index
-            resources[nat_eip_resource] = nat_eip_clone
-            outputs[nat_eip_resource] = {
-                'Value': {'Fn::If': ['MultiAzNat',
-                                     {'Ref': nat_eip_resource}, '']}
-            }
+            if private_nat_gateway:
+                # Each AZ _can_ have a NAT gateway:
+                nat_eip_clone = deepcopy(base_nat_eip)
+                nat_eip_clone['Condition'] = 'MultiAzNat'
+                nat_eip_resource = 'NatEip%02d' % az_index
+                resources[nat_eip_resource] = nat_eip_clone
+                outputs[nat_eip_resource] = {
+                    'Value': {'Fn::If': ['MultiAzNat',
+                                         {'Ref': nat_eip_resource}, '']}
+                }
 
-            # Each AZ _can_ have a NAT gateway:
-            nat_gateway_clone = deepcopy(base_nat_gateway)
-            nat_gateway_clone['Condition'] = 'MultiAzNat'
-            nat_gateway_props = nat_gateway_clone['Properties']
-            nat_gateway_props['SubnetId']['Ref'] = nat_subnet_resource
-            nat_gateway_props['AllocationId']['Fn::GetAtt'][0] = \
-                nat_eip_resource
-            nat_gateway_resource = 'NatGateway%02d' % az_index
-            resources[nat_gateway_resource] = nat_gateway_clone
+                # Each AZ _can_ have a NAT gateway:
+                nat_gateway_clone = deepcopy(base_nat_gateway)
+                nat_gateway_clone['Condition'] = 'MultiAzNat'
+                nat_gateway_props = nat_gateway_clone['Properties']
+                nat_gateway_props['SubnetId']['Ref'] = nat_subnet_resource
+                nat_gateway_props['AllocationId']['Fn::GetAtt'][0] = \
+                    nat_eip_resource
+                nat_gateway_resource = 'NatGateway%02d' % az_index
+                resources[nat_gateway_resource] = nat_gateway_clone
 
             # Each private route table has a default NAT route:
             private_default_route_clone = deepcopy(base_default_route)
             private_route_props = private_default_route_clone['Properties']
             private_route_props['RouteTableId']['Ref'] = private_rt_resource
-            private_route_props['NatGatewayId'] = {
-                'Fn::If': [
-                    'MultiAzNat', {'Ref': nat_gateway_resource},
-                    {'Ref': 'NatGateway01'}
-                ]
-            }
+            if private_nat_gateway:
+                private_route_props['NatGatewayId'] = {
+                    'Fn::If': [
+                        'MultiAzNat', {'Ref': nat_gateway_resource},
+                        {'Ref': 'NatGateway01'}
+                    ]
+                }
+            else:
+                del private_route_props['NatGatewayId']
+                private_route_props['GatewayId'] = {
+                    'Ref': 'InternetGateway'
+                }
             private_route_resource = 'PrivateRouteTable%02dDefaultRoute' % \
                                      az_index
             resources[private_route_resource] = private_default_route_clone
@@ -112,6 +122,16 @@ class VpcTemplate(BaseTemplateCache):
         self._add_subnet_ids(resources, azs, 'PrivateCache')
         self._add_subnet_ids(resources, azs, 'PublicRds')
         self._add_subnet_ids(resources, azs, 'PrivateRds')
+
+        if not private_nat_gateway:
+            private_route_table_default_route = (
+                resources['PrivateRouteTable01DefaultRoute']['Properties'])
+            del (resources['NatGateway01'], resources['NatEip01'],
+                 private_route_table_default_route['NatGatewayId'])
+            private_route_table_default_route['GatewayId'] = {
+                'Ref': 'InternetGateway'
+            }
+            outputs['NatEip01']['Value'] = ''
 
         return vpc_template
 

--- a/src/spacel/provision/template/vpc.py
+++ b/src/spacel/provision/template/vpc.py
@@ -99,25 +99,19 @@ class VpcTemplate(BaseTemplateCache):
                 nat_gateway_resource = 'NatGateway%02d' % az_index
                 resources[nat_gateway_resource] = nat_gateway_clone
 
-            # Each private route table has a default NAT route:
-            private_default_route_clone = deepcopy(base_default_route)
-            private_route_props = private_default_route_clone['Properties']
-            private_route_props['RouteTableId']['Ref'] = private_rt_resource
-            if private_nat_gateway:
+                # Each private route table has a default NAT route:
+                private_default_route_clone = deepcopy(base_default_route)
+                private_route_props = private_default_route_clone['Properties']
+                private_route_props['RouteTableId']['Ref'] = private_rt_resource
                 private_route_props['NatGatewayId'] = {
                     'Fn::If': [
                         'MultiAzNat', {'Ref': nat_gateway_resource},
                         {'Ref': 'NatGateway01'}
                     ]
                 }
-            else:
-                del private_route_props['NatGatewayId']
-                private_route_props['GatewayId'] = {
-                    'Ref': 'InternetGateway'
-                }
-            private_route_resource = 'PrivateRouteTable%02dDefaultRoute' % \
-                                     az_index
-            resources[private_route_resource] = private_default_route_clone
+                private_route_resource = 'PrivateRouteTable%02dDefaultRoute' % \
+                                         az_index
+                resources[private_route_resource] = private_default_route_clone
 
         self._add_subnet_ids(resources, azs, 'PrivateCache')
         self._add_subnet_ids(resources, azs, 'PublicRds')
@@ -127,6 +121,7 @@ class VpcTemplate(BaseTemplateCache):
             private_route_table_default_route = (
                 resources['PrivateRouteTable01DefaultRoute']['Properties'])
             del (resources['NatGateway01'], resources['NatEip01'],
+                 resources['PrivateRouteTable01DefaultRoute'],
                  private_route_table_default_route['NatGatewayId'])
             private_route_table_default_route['GatewayId'] = {
                 'Ref': 'InternetGateway'

--- a/src/test/provision/app/test_space.py
+++ b/src/test/provision/app/test_space.py
@@ -18,7 +18,7 @@ class TestSpaceElevatorAppFactory(unittest.TestCase):
         self.change_sets = MagicMock(spec=ChangeSetEstimator)
         self.templates = MagicMock(spec=TemplateUploader)
         self.app_template = MagicMock(spec=AppTemplate)
-        self.app_template.app.return_value = {}, {}
+        self.app_template.app.return_value = {'Spacel': 'Rules'}, {}
 
         self.provisioner = SpaceElevatorAppFactory(self.clients,
                                                    self.change_sets,
@@ -46,4 +46,11 @@ class TestSpaceElevatorAppFactory(unittest.TestCase):
 
         self.assertEquals(len(REGIONS),
                           self.provisioner._delete_stack.call_count)
+        self.assertEquals(1, self.provisioner._wait_for_updates.call_count)
+
+    def test_app_syntax_rejected(self):
+        self.app_template.app.return_value = False, False
+        self.provisioner.app(self.app)
+
+        self.provisioner._stack.assert_not_called()
         self.assertEquals(1, self.provisioner._wait_for_updates.call_count)

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -44,7 +44,6 @@ class TestAppTemplate(BaseSpaceAppTest):
         resources = app['Resources']
 
         self.assertEquals(params['VirtualHostDomain']['Default'], 'test.com.')
-
         self.assertEquals(params['VirtualHost']['Default'], DOMAIN_NAME)
 
         block_devs = resources['Lc']['Properties']['BlockDeviceMappings']
@@ -77,6 +76,13 @@ class TestAppTemplate(BaseSpaceAppTest):
         public_addr = (app['Resources']['Lc']['Properties']
                           ['AssociatePublicIpAddress'])
         self.assertEqual(True, public_addr)
+
+    def test_app_availability_nat_gateway(self):
+        self.app.instance_availability = 'private'
+        self.orbit.get_param = MagicMock(return_value=False)
+
+        app, _ = self.cache.app(self.app, REGION)
+        self.assertEqual(app, False)
 
     def test_app_no_loadbalancer(self):
         self.app.loadbalancer = False

--- a/src/test/provision/template/test_vpc.py
+++ b/src/test/provision/template/test_vpc.py
@@ -32,9 +32,6 @@ class TestVpcTemplate(unittest.TestCase):
         vpc_resources = vpc['Resources']
 
         self.assertNotIn('NatGateway01', vpc_resources)
-        route = vpc_resources['PrivateRouteTable02DefaultRoute']['Properties']
-        self.assertNotIn('NatGatewayId', route)
-        self.assertIn('GatewayId', route)
 
     def test_vpc(self):
         self.vpc_regions('us-east-1a', 'us-east-1b')

--- a/src/test/provision/template/test_vpc.py
+++ b/src/test/provision/template/test_vpc.py
@@ -4,6 +4,8 @@ from spacel.model import Orbit
 from spacel.provision.template.vpc import VpcTemplate
 
 REGION = 'us-east-1'
+AZA = 'us-east-1a'
+AZB = 'us-east-1b'
 
 
 class TestVpcTemplate(unittest.TestCase):
@@ -19,6 +21,20 @@ class TestVpcTemplate(unittest.TestCase):
         # No resources injected:
         vpc_resources = len(vpc['Resources'])
         self.assertEquals(self.base_resources, vpc_resources)
+
+    def test_vpc_no_private_nat_gateway(self):
+        args = {'private_nat_gateway': 'disabled'}
+        self.orbit._azs = {REGION: [AZA, AZB]}
+        self.orbit._params = {REGION: args}
+        vpc = self.cache.vpc(self.orbit, REGION)
+
+        # No nat gateway injected
+        vpc_resources = vpc['Resources']
+
+        self.assertNotIn('NatGateway01', vpc_resources)
+        route = vpc_resources['PrivateRouteTable02DefaultRoute']['Properties']
+        self.assertNotIn('NatGatewayId', route)
+        self.assertIn('GatewayId', route)
 
     def test_vpc(self):
         self.vpc_regions('us-east-1a', 'us-east-1b')


### PR DESCRIPTION
Fixes #45 

This makes it possible to deploy a $5/m (`t2.nano`) in just a few minutes with `spacel-provision`.

When trying to use `private` with NAT gateway disabled, we return an error and skip trying to deploy that template. Private subnets are pointed via the internet gateway to keep them around.