### PR TITLE
Feature flag: Elastic IPs for Apps

### DIFF
--- a/sample/app/http-env-echo-bare-minimum.json
+++ b/sample/app/http-env-echo-bare-minimum.json
@@ -1,0 +1,22 @@
+{
+  "name": "http-env-echo",
+  "elastic_ips": "enabled",
+  "elb_availability": "disabled",
+  "instance_availability": "internet-facing",
+  "instance_type": "t2.nano",
+  "instance_min": 1,
+  "instance_max": 1,
+  "services": {
+    "http-env-echo": {
+      "image": "pwagner/http-env-echo",
+      "ports": {
+        "80": 8080
+      }
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    }
+  }
+}

--- a/sample/app/http-env-echo-elastic-ips.json
+++ b/sample/app/http-env-echo-elastic-ips.json
@@ -1,0 +1,26 @@
+{
+  "name": "http-env-echo",
+  "health_check": "HTTP:80/",
+  "elastic_ips": "enabled",
+  "instance_availability": "internet-facing",
+  "instance_type": "t2.nano",
+  "instance_min": 1,
+  "instance_max": 1,
+  "services": {
+    "http-env-echo": {
+      "image": "pwagner/http-env-echo",
+      "ports": {
+        "80": 8080
+      }
+    }
+  },
+  "public_ports": {
+    "80": {
+      "sources": ["0.0.0.0/0"]
+    },
+    "443": {
+      "sources": ["0.0.0.0/0"],
+      "internal_port": 80
+    }
+  }
+}

--- a/sample/orbit/develop.json
+++ b/sample/orbit/develop.json
@@ -2,8 +2,7 @@
   "name": "develop",
   "domain": "pebbledev.com",
   "regions": [
-    "us-east-1",
-    "us-west-2"
+    "us-east-1"
   ],
   "us-east-1": {
     "bastion_instance_count": 0

--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -19,8 +19,8 @@ class SpaceApp(object):
             self.regions = orbit.regions
         self.hostnames = params.get('hostnames', ())
         self.instance_type = params.get('instance_type', 't2.nano')
-        self.instance_min = params.get('instance_min', 1)
-        self.instance_max = params.get('instance_max', 2)
+        self.instance_min = int(params.get('instance_min', 1))
+        self.instance_max = int(params.get('instance_max', 2))
         self.health_check = params.get('health_check', 'TCP:80')
         self.local_health_check = params.get('health_check', 'TCP:80')
 
@@ -29,6 +29,8 @@ class SpaceApp(object):
         self.elb_availability = params.get('elb_availability',
                                            'internet-facing')
         self.loadbalancer = self.elb_availability != 'disabled'
+
+        self.elastic_ips = params.get('elastic_ips', 'disabled') == 'enabled'
 
         public_ports = params.get('public_ports', {80: {}})
         self.public_ports = {port: SpaceServicePort(port, port_params)

--- a/src/spacel/provision/template/app.py
+++ b/src/spacel/provision/template/app.py
@@ -126,7 +126,8 @@ class AppTemplate(BaseTemplateCache):
                                 'Effect': 'Allow',
                                 'Action': [
                                     'ec2:AssociateAddress',
-                                    'ec2:DescribeAddresses'
+                                    'ec2:DescribeAddresses',
+                                    'ec2:DescribeInstances'
                                 ],
                                 'Resource': '*'
                             }

--- a/src/test/provision/app/test_ingress_resource.py
+++ b/src/test/provision/app/test_ingress_resource.py
@@ -41,7 +41,7 @@ class TestIngressResourceFactory(unittest.TestCase):
         self.assertEquals('10.0.0.0/16', resource['Properties']['CidrIp'])
 
     def test_ingress_resources_other_region_nat(self):
-        self.ingress.app_eips = MagicMock(return_value=[])
+        self.ingress._app_eips = MagicMock(return_value=[])
         resources = self._http_ingress(OTHER_REGION)
         # 1 per Nat EIP:
         self.assertEquals(3, len(resources))
@@ -49,7 +49,7 @@ class TestIngressResourceFactory(unittest.TestCase):
             self.assertIn('CidrIp', resource['Properties'])
 
     def test_ingress_resources_other_region(self):
-        self.ingress.app_eips = MagicMock(return_value=['1.1.1.1', '2.2.2.2'])
+        self.ingress._app_eips = MagicMock(return_value=['1.1.1.1', '2.2.2.2'])
         resources = self._http_ingress(OTHER_REGION)
         # 1 per Nat EIP:
         self.assertEquals(2, len(resources))
@@ -57,14 +57,14 @@ class TestIngressResourceFactory(unittest.TestCase):
             self.assertIn('CidrIp', resource['Properties'])
 
     def test_ingress_resource_app(self):
-        self.ingress.app_sg = MagicMock(return_value=SECURITY_GROUP)
+        self.ingress._app_sg = MagicMock(return_value=SECURITY_GROUP)
         resource = self._only(self._http_ingress('foo'))
         self.assertNotIn('CidrIp', resource['Properties'])
         self.assertEquals(SECURITY_GROUP,
                           resource['Properties']['SourceSecurityGroupId'])
 
     def test_ingress_resource_app_not_found(self):
-        self.ingress.app_sg = MagicMock(return_value=None)
+        self.ingress._app_sg = MagicMock(return_value=None)
         resources = self._http_ingress('foo')
         self.assertEquals(0, len(resources))
 
@@ -75,37 +75,50 @@ class TestIngressResourceFactory(unittest.TestCase):
             }
         }
 
-        sg = self.ingress.app_sg(self.orbit, REGION, 'test-app')
+        sg = self.ingress._app_sg(self.orbit, REGION, 'test-app')
         self.assertEquals(SECURITY_GROUP, sg)
 
     def test_app_sg_not_found(self):
         self._describe_stack_resource_error('Stack does not exist')
-        sg = self.ingress.app_sg(self.orbit, REGION, 'test-app')
+        sg = self.ingress._app_sg(self.orbit, REGION, 'test-app')
         self.assertIsNone(sg)
 
     def test_app_sg_error(self):
         self._describe_stack_resource_error('Kaboom')
-        self.assertRaises(ClientError, self.ingress.app_sg, self.orbit, REGION,
+        self.assertRaises(ClientError, self.ingress._app_sg, self.orbit, REGION,
                           'test-app')
 
     def test_app_eips(self):
-        self.cloudformation.describe_stack_resource.side_effect = [{
-            'StackResourceDetail': {
+        resourceList = [{
+            'StackResourceSummaries': [{
+                'LogicalResourceId': 'ElasticIp01',
                 'PhysicalResourceId': ELASTIC_IP
-            }
-        }, ClientError({
-            'Error': {
-                'Message': 'Resource does not exist'
-            }
-        }, 'ElasticIp')]
+            }]
+        }]
+        pages = MagicMock()
+        pages.paginate = MagicMock(return_value=resourceList)
+        self.cloudformation.get_paginator = MagicMock(return_value=pages)
 
-        eips = self.ingress.app_eips(self.orbit, REGION, 'test-app')
+        eips = self.ingress._app_eips(self.orbit, REGION, 'test-app')
         self.assertIn(ELASTIC_IP, eips)
 
     def test_app_eips_error(self):
-        self._describe_stack_resource_error('Kaboom')
-        self.assertRaises(ClientError, self.ingress.app_eips, self.orbit, 
+        self.cloudformation.get_paginator.side_effect = ClientError({
+            'Error': {
+                'Message': 'Kaboom'
+            }
+        }, 'GetPaginator')
+        self.assertRaises(ClientError, self.ingress._app_eips, self.orbit,
                           REGION, 'test-app')
+
+    def test_app_eips_cloudformation_stack_does_not_exist(self):
+        self.cloudformation.get_paginator.side_effect = ClientError({
+            'Error': {
+                'Message': 'CloudFormation stack does not exist'
+            }
+        }, 'GetPaginator')
+        eips = self.ingress._app_eips(self.orbit, REGION, 'test-app')
+        self.assertEquals(0, len(eips))
 
     def _http_ingress(self, *args):
         return self.ingress.ingress_resources(self.orbit, REGION, 80, args)

--- a/src/test/provision/app/test_ingress_resource.py
+++ b/src/test/provision/app/test_ingress_resource.py
@@ -51,7 +51,7 @@ class TestIngressResourceFactory(unittest.TestCase):
     def test_ingress_resources_other_region(self):
         self.ingress._app_eips = MagicMock(return_value=['1.1.1.1', '2.2.2.2'])
         resources = self._http_ingress(OTHER_REGION)
-        # 1 per Nat EIP:
+        # 1 per App EIP:
         self.assertEquals(2, len(resources))
         for resource in resources.values():
             self.assertIn('CidrIp', resource['Properties'])
@@ -89,14 +89,14 @@ class TestIngressResourceFactory(unittest.TestCase):
                           'test-app')
 
     def test_app_eips(self):
-        resourceList = [{
+        resource_list = [{
             'StackResourceSummaries': [{
                 'LogicalResourceId': 'ElasticIp01',
                 'PhysicalResourceId': ELASTIC_IP
             }]
         }]
         pages = MagicMock()
-        pages.paginate = MagicMock(return_value=resourceList)
+        pages.paginate = MagicMock(return_value=resource_list)
         self.cloudformation.get_paginator = MagicMock(return_value=pages)
 
         eips = self.ingress._app_eips(self.orbit, REGION, 'test-app')

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -98,6 +98,18 @@ class TestAppTemplate(BaseSpaceAppTest):
         self.assertEqual('EC2', app['Resources']['Asg']['Properties']
                                    ['HealthCheckType'])
 
+    def test_app_elastic_ips(self):
+        self.app.elastic_ips = True
+        self.app.max_instances = 2
+
+        app, _ = self.cache.app(self.app, REGION)
+
+        self.assertIn('ElasticIp01', app['Resources'])
+        self.assertIn('ElasticIp02', app['Resources'])
+
+        self.assertIn('"eips":',
+                      str(app['Resources']['Lc']['Properties']['UserData']))
+
     def test_app_private_ports(self):
         self.app.private_ports = {123: ['TCP']}
 

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -98,6 +98,27 @@ class TestAppTemplate(BaseSpaceAppTest):
         self.assertEqual('EC2', app['Resources']['Asg']['Properties']
                                    ['HealthCheckType'])
 
+    def test_app_no_loadbalancer_elastic_ips(self):
+        self.app.loadbalancer = False
+        self.app.elastic_ips = True
+        self.app.max_instances = 2
+
+        app, _ = self.cache.app(self.app, REGION)
+
+        self.assertIn('DnsRecord', app['Resources'])
+        self.assertIn(
+            'ElasticIp01',
+            app['Resources']['DnsRecord']['Properties']['RecordSets'][0]
+               ['ResourceRecords'][0]['Ref'])
+
+    def test_app_no_loadbalancer_no_elastic_ips(self):
+        self.app.loadbalancer = False
+        self.app.elastic_ips = False
+
+        app, _ = self.cache.app(self.app, REGION)
+
+        self.assertNotIn('DnsRecord', app['Resources'])
+
     def test_app_elastic_ips(self):
         self.app.elastic_ips = True
         self.app.max_instances = 2

--- a/src/test_integ/__init__.py
+++ b/src/test_integ/__init__.py
@@ -98,8 +98,10 @@ class BaseIntegrationTest(unittest.TestCase):
         return app
 
     @staticmethod
-    def _get(url):
+    def _get(url, https=True):
         full_url = '%s/%s' % (BaseIntegrationTest.APP_URL, url)
+        if not https:
+            full_url = full_url.replace('https://', 'http://')
         return requests.get(full_url)
 
     @staticmethod

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -73,9 +73,19 @@ ExecStop=/usr/bin/docker stop %n
         self.provision()
         self._verify_message('top secret')
 
-    def _verify_deploy(self, version=None):
+    def test_07_eip_no_elb(self):
+        """Deploy a service without ELB and with Elastic IP, verify."""
+        self.app_params['instance_max'] = 1
+        self.app_params['elb_availability'] = 'disabled'
+        self.app_params['instance_availability'] = 'internet-facing'
+        self.app_params['elastic_ips'] = 'enabled'
+
+        self.provision()
+        self._verify_deploy(https=False)
+
+    def _verify_deploy(self, version=None, https=True):
         version = version or BaseIntegrationTest.APP_VERSION
-        r = self._get('')
+        r = self._get('', https=https)
         self.assertEquals(version, r.json()['version'])
 
     def _verify_message(self, message=''):


### PR DESCRIPTION
Adds feature flag to apps: `elastic_ips: "enabled||disabled"`

Fixes #50

This is still missing:
  - [x] ~~test integration~~
  - [x] ~~the [ingress_resource suggestion](https://github.com/pebble/spacel-provision/issues/50#issuecomment-260122361)~~