### PR TITLE
WEBOPS-972: `AppRegion.stats` flag

### DIFF
--- a/src/spacel/model/app.py
+++ b/src/spacel/model/app.py
@@ -75,6 +75,7 @@ class SpaceAppRegion(object):
     def __init__(self,
                  app,
                  orbit_region,
+                 cw_stats=False,
                  elastic_ips=False,
                  elb_availability='internet-facing',
                  health_check='TCP:80',
@@ -89,6 +90,7 @@ class SpaceAppRegion(object):
         self.app = app
         self.orbit_region = orbit_region
         self.region = orbit_region.region
+        self.cw_stats = cw_stats
         self.elastic_ips = elastic_ips
         self.elb_availability = elb_availability
         self.health_check = health_check

--- a/src/test/provision/template/test_app.py
+++ b/src/test/provision/template/test_app.py
@@ -277,6 +277,15 @@ class TestAppTemplate(BaseTemplateTest):
         user_data = self.cache._user_data(params, self.app_region)
         self.assertIn('meow==', user_data)
 
+    def test_user_data_stats_noop(self):
+        user_data = self.cache._user_data({}, self.app_region)
+        self.assertNotIn('"stats"', user_data)
+
+    def test_user_data_stats(self):
+        self.app_region.cw_stats = True
+        user_data = self.cache._user_data({}, self.app_region)
+        self.assertIn('"stats":true', user_data)
+
     def test_add_kms_iam_policy_noop(self):
         resources = {}
         self.cache._add_kms_iam_policy(self.app_region, resources)
@@ -290,3 +299,17 @@ class TestAppTemplate(BaseTemplateTest):
 
         self.assertEquals(1, len(resources))
         self.assertIn('KmsKeyPolicy', resources)
+
+    def test_add_cloudwatch_iam_policy_noop(self):
+        resources = {}
+        self.cache._add_cloudwatch_iam_policy(self.app_region, resources)
+
+        self.assertEquals({}, resources)
+
+    def test_add_cloudwatch_iam_policy(self):
+        self.app_region.cw_stats = True
+        resources = {}
+        self.cache._add_cloudwatch_iam_policy(self.app_region, resources)
+
+        self.assertEquals(1, len(resources))
+        self.assertIn('CloudWatchPutPolicy', resources)

--- a/src/test_integ/test_deploy.py
+++ b/src/test_integ/test_deploy.py
@@ -88,6 +88,7 @@ ExecStop=/usr/bin/docker stop %n
             app_region.elb_availability = 'disabled'
             app_region.instance_availability = 'internet-facing'
             app_region.elastic_ips = True
+            app_region.cw_stats = True
 
         self.provision()
         self._verify_deploy(https=False)


### PR DESCRIPTION
This tells `spacel-agent` that we want `cloudwatch-stats.service`
started, pretty please.

Requires:
- https://github.com/pebble/vz-spacel-agent/pull/8
- https://github.com/pebble/spacel-agent/pull/42