### PR TITLE
Apps use ingress resource factory

### DIFF
--- a/src/spacel/cli/provision.py
+++ b/src/spacel/cli/provision.py
@@ -6,6 +6,7 @@ from spacel.model.aws import VALID_REGIONS
 from spacel.provision import (ChangeSetEstimator, LambdaUploader,
                               TemplateUploader)
 from spacel.provision.app import (AppSpotTemplateDecorator,
+                                  CloudWatchLogsDecorator,
                                   IngressResourceFactory)
 from spacel.provision.app import SpaceElevatorAppFactory
 from spacel.provision.app.alarm import AlarmFactory
@@ -114,13 +115,15 @@ def provision(app,
     password_manager = PasswordManager(clients, kms_crypto)
     cache_factory = CacheFactory(ingress_factory)
     rds_factory = RdsFactory(clients, ingress_factory, password_manager)
+    cw_logs = CloudWatchLogsDecorator()
     # Templates:
     ami_finder = AmiFinder(spacel_agent_channel,
                            cache_bust=spacel_agent_cache_bust)
     app_spot = AppSpotTemplateDecorator()
     acm = AcmCertificates(clients)
     app_template = AppTemplate(ami_finder, alarm_factory, cache_factory,
-                               rds_factory, app_spot, acm, kms_key_factory)
+                               rds_factory, app_spot, acm, kms_key_factory,
+                               cw_logs, ingress_factory)
     bastion_template = BastionTemplate(ami_finder)
     tables_template = TablesTemplate()
     vpc_template = VpcTemplate()

--- a/src/spacel/provision/app/__init__.py
+++ b/src/spacel/provision/app/__init__.py
@@ -1,3 +1,4 @@
 from .app_spot import AppSpotTemplateDecorator
+from .cloudwatch_logs import CloudWatchLogsDecorator
 from .ingress_resource import IngressResourceFactory
 from .space import SpaceElevatorAppFactory

--- a/src/spacel/provision/app/db/base.py
+++ b/src/spacel/provision/app/db/base.py
@@ -13,11 +13,9 @@ class BaseDbTemplateDecorator(BaseTemplateDecorator):
     def _add_client_resources(self, resources, app_region, port, params,
                               sg_ref):
         clients = params.get('clients', ())
-        ingress_resources = self._ingress.ingress_resources(
-            app_region.app.orbit,
-            app_region.region,
-            port,
-            clients,
-            sg_ref=sg_ref)
+        ingress_resources = self._ingress.ingress_resources(app_region,
+                                                            port,
+                                                            clients,
+                                                            sg_ref=sg_ref)
         logger.debug('Adding %s ingress rules.', len(ingress_resources))
         resources.update(ingress_resources)

--- a/src/spacel/provision/app/ingress_resource.py
+++ b/src/spacel/provision/app/ingress_resource.py
@@ -13,12 +13,11 @@ class IngressResourceFactory(object):
     def __init__(self, clients):
         self._clients = clients
 
-    def ingress_resources(self, orbit, region, start_port, clients,
+    def ingress_resources(self, app_region, start_port, clients,
                           protocol='TCP', end_port=None, sg_ref='Sg'):
         """
         Return ingress resources for access from a list of clients.
-        :param orbit:  Orbit definition.
-        :param region: Region.
+        :param app_region:  AppRegion.
         :param start_port: First port to open
         :param clients: Client list.
         :param protocol: Protocol.
@@ -27,6 +26,8 @@ class IngressResourceFactory(object):
         :return: dict of {resource_name: cloudformation_resource}
         """
         # Parameter normalization:
+        orbit = app_region.orbit_region.orbit
+        region = app_region.orbit_region.region
         if not end_port:
             end_port = start_port
 

--- a/src/spacel/provision/app/ingress_resource.py
+++ b/src/spacel/provision/app/ingress_resource.py
@@ -5,8 +5,14 @@ from botocore.exceptions import ClientError
 
 from spacel.provision import clean_name
 
-IP_BLOCK = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,3}'
+IP_BLOCK = re.compile('(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3}/\d{1,3})')
 logger = logging.getLogger('spacel.provision.ingress_resource')
+
+# See: INSTANCE_AVAILABILITY and ELB_AVAILABILITY in SpaceAppRegion.
+AVAILABILITY_NOT_PUBLIC = {
+    'multi-region',
+    'private'
+}
 
 
 class IngressResourceFactory(object):
@@ -14,7 +20,8 @@ class IngressResourceFactory(object):
         self._clients = clients
 
     def ingress_resources(self, app_region, start_port, clients,
-                          protocol='TCP', end_port=None, sg_ref='Sg'):
+                          protocol='TCP', end_port=None, sg_ref='Sg',
+                          availability=None):
         """
         Return ingress resources for access from a list of clients.
         :param app_region:  AppRegion.
@@ -23,6 +30,7 @@ class IngressResourceFactory(object):
         :param protocol: Protocol.
         :param end_port: Last port to open (defaults to start_port if not set).
         :param sg_ref: Security group name.
+        :param availability: Resource availability.
         :return: dict of {resource_name: cloudformation_resource}
         """
         # Parameter normalization:
@@ -56,7 +64,14 @@ class IngressResourceFactory(object):
         # Clients can be...
         for client in clients:
             # An IP block:
-            if re.match(IP_BLOCK, client):
+            ip_match = IP_BLOCK.match(client)
+            if ip_match:
+                rfc1918 = self._is_rfc1918(ip_match)
+                if not rfc1918 and availability in AVAILABILITY_NOT_PUBLIC:
+                    logger.warning('Ignoring IP %s for %s service.', client,
+                                   availability)
+                    continue
+
                 logger.debug('Adding access from %s.', client)
                 ingress_resource(client, CidrIp=client)
                 continue
@@ -131,3 +146,14 @@ class IngressResourceFactory(object):
             if 'does not exist' in e_message:
                 return eips
             raise e
+
+    @staticmethod
+    def _is_rfc1918(ip_match):
+        first_octet = ip_match.group(1)
+        if first_octet == '10':
+            return True
+        if first_octet == '172':
+            return 16 <= int(ip_match.group(2)) < 32
+        if first_octet == '192':
+            return ip_match.group(2) == '168'
+        return False

--- a/src/test/provision/app/test_ingress_resource.py
+++ b/src/test/provision/app/test_ingress_resource.py
@@ -111,8 +111,7 @@ class TestIngressResourceFactory(BaseSpaceAppTest):
         self.assertEquals(0, len(eips))
 
     def _http_ingress(self, *args):
-        return self.ingress.ingress_resources(self.orbit, ORBIT_REGION, 80,
-                                              args)
+        return self.ingress.ingress_resources(self.app_region, 80, args)
 
     def _only(self, resources):
         self.assertEquals(1, len(resources))

--- a/src/test/provision/app/test_ingress_resource.py
+++ b/src/test/provision/app/test_ingress_resource.py
@@ -3,11 +3,13 @@ from botocore.exceptions import ClientError
 from mock import MagicMock
 
 from spacel.aws import ClientCache
-from spacel.provision.app.ingress_resource import IngressResourceFactory
+from spacel.provision.app.ingress_resource import (IngressResourceFactory,
+                                                   IP_BLOCK)
 from test import BaseSpaceAppTest, ORBIT_REGION
 
 OTHER_REGION = 'us-east-1'
-IP_BLOCK = '127.0.0.1/32'
+PUBLIC_IP_BLOCK = '8.8.8.8/32'
+PRIVATE_IP_BLOCK = '192.168.0.0/16'
 SECURITY_GROUP = 'sg-123456'
 ELASTIC_IP = '1.1.1.1'
 
@@ -24,12 +26,12 @@ class TestIngressResourceFactory(BaseSpaceAppTest):
         self._multi_region()
 
     def test_ingress_resources_ip_block(self):
-        resource = self._only(self._http_ingress(IP_BLOCK))
-        self.assertEquals(IP_BLOCK, resource['Properties']['CidrIp'])
+        resource = self._only(self._http_ingress(PUBLIC_IP_BLOCK))
+        self.assertEquals(PUBLIC_IP_BLOCK, resource['Properties']['CidrIp'])
 
     def test_ingress_resources_region(self):
         resource = self._only(self._http_ingress(ORBIT_REGION))
-        self.assertEquals('192.168.0.0/16', resource['Properties']['CidrIp'])
+        self.assertEquals(PRIVATE_IP_BLOCK, resource['Properties']['CidrIp'])
 
     def test_ingress_resources_other_region_nat(self):
         self.ingress._app_eips = MagicMock(return_value=[])
@@ -110,8 +112,31 @@ class TestIngressResourceFactory(BaseSpaceAppTest):
         eips = self.ingress._app_eips(self.orbit_region, 'test-app')
         self.assertEquals(0, len(eips))
 
-    def _http_ingress(self, *args):
-        return self.ingress.ingress_resources(self.app_region, 80, args)
+    def test_ingress_resources_availability_internet(self):
+        self._availability(PUBLIC_IP_BLOCK, 'internet-facing', True)
+        self._availability(PRIVATE_IP_BLOCK, 'internet-facing', True)
+
+    def test_ingress_resources_availability_multiregion(self):
+        self._availability(PUBLIC_IP_BLOCK, 'multi-region', False)
+        self._availability(PRIVATE_IP_BLOCK, 'multi-region', True)
+
+    def test_ingress_resources_availability_private(self):
+        self._availability(PUBLIC_IP_BLOCK, 'private', False)
+        self._availability(PRIVATE_IP_BLOCK, 'private', True)
+
+    def test_is_rfc1918(self):
+        self.assertTrue(self._rfc1918(PRIVATE_IP_BLOCK))
+        self.assertTrue(self._rfc1918('10.0.0.0/8'))
+        self.assertTrue(self._rfc1918('172.16.0.0/12'))
+        self.assertTrue(self._rfc1918('192.168.0.0/16'))
+
+        self.assertFalse(self._rfc1918(PUBLIC_IP_BLOCK))
+        self.assertFalse(self._rfc1918('172.15.0.0/24'))
+        self.assertFalse(self._rfc1918('192.167.0.0/24'))
+
+    def _http_ingress(self, *args, **kwargs):
+        return self.ingress.ingress_resources(self.app_region, 80, args,
+                                              **kwargs)
 
     def _only(self, resources):
         self.assertEquals(1, len(resources))
@@ -123,3 +148,11 @@ class TestIngressResourceFactory(BaseSpaceAppTest):
                 'Message': message
             }
         }, 'CreateSubnet')
+
+    def _availability(self, param, availability, allowed):
+        resources = self._http_ingress(param, availability=availability)
+        self.assertEquals(allowed and 1 or 0, len(resources))
+
+    def _rfc1918(self, ip_block):
+        ip_match = IP_BLOCK.match(ip_block)
+        return self.ingress._is_rfc1918(ip_match)


### PR DESCRIPTION
This is 50% planned refactor: backport `IngressResourceFactory`(introduced for ElastiCache/RDS support) to the `SpaceApp.public_ports[].sources[]` structure.
This provides stronger security for `elb_availability=private` applications (i.e. a `kafka` app could whiltelist specific producers/consumers, instead of allowing the entire VPC by CIDR). Noice.

The other 50% is propagating the `availability` flag to IngressResourceFactory, so that it can make the user think twice before exposing a `elb_availability=multi-region` service as if it were `elb_availability=public`. 

The latter fixes #56 