### PR TITLE
App version/docker tag via CLI

### DIFF
--- a/src/spacel/cli/helper.py
+++ b/src/spacel/cli/helper.py
@@ -41,15 +41,21 @@ class ClickHelper(object):
             return self._orbit_factory.orbit(orbit_params, regions=regions)
         return Orbit(name=orbit_param, regions=regions)
 
-    def app(self, orbit, app_param):
+    def app(self, orbit, app_param, version=None):
+        app = self._app(orbit, app_param)
+        if version:
+            for app_region in app.regions.values():
+                for service in app_region.services.values():
+                    service.version = version
+        return app
+
+    def _app(self, orbit, app_param):
         app_params = self.read_manifest(app_param, 'app')
         if app_params:
             return self._app_json_factory.app(orbit, app_params)
-
         url = urlparse(app_param)
         if isdir(url.path):
             return self._app_files_factory.app(orbit, url.path)
-
         return SpaceApp(orbit, name=app_param)
 
     def read_manifest(self, path, label):

--- a/src/spacel/cli/provision.py
+++ b/src/spacel/cli/provision.py
@@ -55,16 +55,18 @@ def provision_cmd():  # pragma: no cover
               help='Spacel agent AMI cache bust.')
 @click.option('--log-level', default='INFO', type=click.Choice(LOG_LEVELS),
               help='Log level')
+@click.option('--version', type=click.STRING, help='Version to deploy')
 def provision_cli(orbit, app, region, lambda_bucket, lambda_region,
                   template_bucket, template_region, pagerduty_default,
                   pagerduty_api_key, spacel_agent_channel,
-                  spacel_agent_cache_bust, log_level):  # pragma: no cover
+                  spacel_agent_cache_bust, log_level,
+                  version):  # pragma: no cover
     provision_services(orbit, app, region,
                        lambda_bucket, lambda_region,
                        template_bucket, template_region,
                        pagerduty_default, pagerduty_api_key,
                        spacel_agent_channel, spacel_agent_cache_bust,
-                       log_level)
+                       log_level, version)
 
 
 def provision_services(orbit_path, app_path, regions,
@@ -72,7 +74,7 @@ def provision_services(orbit_path, app_path, regions,
                        template_bucket, template_region,
                        pagerduty_default, pagerduty_api_key,
                        spacel_agent_channel, spacel_agent_cache_bust,
-                       log_level):
+                       log_level, version):
     helper = ClickHelper()
     helper.setup_logging(log_level)
 
@@ -80,7 +82,7 @@ def provision_services(orbit_path, app_path, regions,
     orbit = helper.orbit(orbit_path, regions)
     if not orbit.valid:
         return -1
-    app = helper.app(orbit, app_path)
+    app = helper.app(orbit, app_path, version)
     if not app.valid:
         return -1
 

--- a/src/spacel/model/service.py
+++ b/src/spacel/model/service.py
@@ -1,16 +1,32 @@
 import os
 
+import six
+
 
 class SpaceService(object):
-    def __init__(self, name, unit_file, environment=None):
+    def __init__(self, name, unit_file, environment=None, version=None):
         self.name = name
-        self.unit_file = unit_file
+        self._unit_file = unit_file
         self.environment = environment or {}
+        self.version = version
+
+    @property
+    def unit_file(self):
+        if isinstance(self._unit_file, six.string_types):
+            version = self.version or 'latest'
+            return self._unit_file.replace('__VERSION__', version)
+        return self._unit_file
+
+    @unit_file.setter
+    def unit_file(self, unit_file):
+        self._unit_file = unit_file
 
 
 class SpaceDockerService(SpaceService):
-    def __init__(self, name, image, ports=None, volumes=None, environment=None):
-        super(SpaceDockerService, self).__init__(name, None, environment)
+    def __init__(self, name, image, ports=None, volumes=None, environment=None,
+                 version=None):
+        super(SpaceDockerService, self).__init__(name, None, environment,
+                                                 version)
         self.image = image
         self.ports = ports or {}
         self.volumes = volumes or {}
@@ -21,6 +37,11 @@ class SpaceDockerService(SpaceService):
         docker_run_flags = '--env-file /files/%s.env' % name_base
         docker_run_flags += self._dict_flags('p', self.ports)
         docker_run_flags += self._dict_flags('v', self.volumes)
+
+        if ':' not in self.image:
+            image = '%s:%s' % (self.image, self.version or 'latest')
+        else:
+            image = self.image
 
         return """[Unit]
 Description={0}
@@ -35,11 +56,7 @@ ExecStartPre=-/usr/bin/docker pull {1}
 ExecStartPre=-/usr/bin/docker rm -f %n
 ExecStart=/usr/bin/docker run --rm --name %n {2} {1}
 ExecStop=/usr/bin/docker stop -t 2 %n
-""".format(self.name, self.image, docker_run_flags)
-
-    @unit_file.setter
-    def unit_file(self, value):
-        pass
+""".format(self.name, image, docker_run_flags)
 
     @staticmethod
     def _dict_flags(flag, items):

--- a/src/test/cli/test_helper.py
+++ b/src/test/cli/test_helper.py
@@ -7,7 +7,7 @@ from six.moves.urllib.error import HTTPError
 from six.moves.urllib.parse import urlparse
 
 from spacel.cli.helper import ClickHelper
-from test import ORBIT_NAME
+from test import ORBIT_NAME, ORBIT_REGION
 
 HTTP_ORBIT = 'http://test.com/orbit'
 FILE_ORBIT = 'test.json'
@@ -38,6 +38,27 @@ class TestClickHelper(unittest.TestCase):
         orbit = MagicMock()
         app = self.helper.app(orbit, 'from-manifest')
         self.assertEquals(ORBIT_NAME, app.name)
+
+    def test_app_from_manifest_version(self):
+        self.helper.read_manifest = MagicMock(return_value={
+            'name': ORBIT_NAME,
+            'all': {
+                'services': {
+                    'test': {
+                        'image': 'test/test:latest'
+                    }
+                }
+            }
+        })
+        orbit = MagicMock()
+        orbit.regions = {ORBIT_REGION: MagicMock()}
+        app = self.helper.app(orbit, 'from-manifest', '1.0.0')
+        found_service = False
+        for app_region in app.regions.values():
+            for service in app_region.services.values():
+                found_service = True
+                self.assertEquals('1.0.0', service.version)
+        self.assertTrue(found_service)
 
     def test_app_from_parameters(self):
         self.helper.read_manifest = MagicMock(return_value=None)

--- a/src/test/cli/test_provision.py
+++ b/src/test/cli/test_provision.py
@@ -17,7 +17,7 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL')
+                           None, None, None, None, 'CRITICAL', None)
         mock_provision.assert_not_called()
 
     @patch('spacel.cli.provision.ClickHelper')
@@ -32,7 +32,7 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL')
+                           None, None, None, None, 'CRITICAL', None)
         mock_provision.assert_not_called()
 
     @patch('spacel.cli.provision.ClickHelper')
@@ -44,6 +44,6 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL')
+                           None, None, None, None, 'CRITICAL', None)
         mock_provision.assert_called_once_with(ANY, None, None, None, None,
                                                None, None, None, None)

--- a/src/test/model/test_service.py
+++ b/src/test/model/test_service.py
@@ -1,7 +1,26 @@
 import unittest
 
-from spacel.model.service import SpaceDockerService
+from spacel.model.service import SpaceService, SpaceDockerService
 from test.model.test_app import SERVICE_NAME, CONTAINER
+
+VERSION = '1.0.0'
+UNIT_FILE = '__VERSION__'
+VERSIONED_CONTAINER = 'foo:1.2.3'
+
+
+class TestSpaceService(unittest.TestCase):
+    def test_unit_file_no_version(self):
+        service = SpaceService(SERVICE_NAME, UNIT_FILE)
+        self.assertEquals('latest', service.unit_file)
+
+    def test_unit_file_version(self):
+        service = SpaceService(SERVICE_NAME, UNIT_FILE, version=VERSION)
+        self.assertEquals(VERSION, service.unit_file)
+
+    def test_unit_file_setter(self):
+        service = SpaceService(SERVICE_NAME, None)
+        service.unit_file = UNIT_FILE
+        self.assertEquals('latest', service.unit_file)
 
 
 class TestSpaceDockerService(unittest.TestCase):
@@ -16,3 +35,17 @@ class TestSpaceDockerService(unittest.TestCase):
         self.assertIn('-p 9300:9300', service.unit_file)
         self.assertIn(' %s' % CONTAINER, service.unit_file)
         self.assertIn('elasticsearch.service', service.name)
+
+    def test_unit_file_no_version(self):
+        service = SpaceDockerService(SERVICE_NAME, CONTAINER)
+        self.assertIn('%s:latest' % CONTAINER, service.unit_file)
+
+    def test_unit_file_version(self):
+        service = SpaceDockerService(SERVICE_NAME, CONTAINER, version=VERSION)
+        self.assertIn('%s:%s' % (CONTAINER, VERSION), service.unit_file)
+
+    def test_unit_file_version_locked(self):
+        service = SpaceDockerService(SERVICE_NAME, VERSIONED_CONTAINER,
+                                     version=VERSION)
+        self.assertNotIn(VERSION, service.unit_file)
+        self.assertIn(VERSIONED_CONTAINER, service.unit_file)


### PR DESCRIPTION
This is for Jenkins: it wants to deploy with `.space/app.json` from the
target repository, _but_ bumping that file with every release is really annoying.

This should behave nicely with: https://github.com/pebble/spacel-laika/blob/master/.space/app.json#L10