### PR TITLE
spacel wrapping script

### DIFF
--- a/spacel.sh
+++ b/spacel.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Where to find AWS credentials:
+AWS_CREDS_FILE="${HOME}/.aws/credentials"
+if [ -f "$AWS_CREDS_FILE" ]; then
+	AWS_CREDS="-v ${AWS_CREDS_FILE}:/root/.aws/credentials"
+else
+	echo "Unable to find AWS credentials"
+	exit 1
+fi
+
+# Pass through environment variables:
+if [ -n "${SPACEL_ORBIT}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e SPACEL_ORBIT=${SPACEL_ORBIT}"
+fi
+if [ -n "${SPACEL_APP}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e SPACEL_APP=${SPACEL_APP}"
+fi
+if [ -n "${SPACEL_LOG_LEVEL}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e SPACEL_LOG_LEVEL=${SPACEL_LOG_LEVEL}"
+fi
+if [ -n "${LAMBDA_BUCKET}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e LAMBDA_BUCKET=${LAMBDA_BUCKET}"
+fi
+if [ -n "${LAMBDA_REGION}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e LAMBDA_REGION=${LAMBDA_REGION}"
+fi
+if [ -n "${SPACEL_AGENT_CHANNEL}" ]; then
+	SPACEL_ENV="${SPACEL_ENV} -e SPACEL_AGENT_CHANNEL=${SPACEL_AGENT_CHANNEL}"
+fi
+
+
+# Which container to use:
+SPACEL_CONTAINER="pebbletech/spacel-provision:latest"
+
+docker run -i --rm ${AWS_CREDS} -v `pwd`:/pwd ${SPACEL_ENV} ${SPACEL_CONTAINER} "$@"
+

--- a/src/spacel/cli/helper.py
+++ b/src/spacel/cli/helper.py
@@ -43,7 +43,7 @@ class ClickHelper(object):
 
     def app(self, orbit, app_param, version=None):
         app = self._app(orbit, app_param)
-        if version:
+        if app and version:
             for app_region in app.regions.values():
                 for service in app_region.services.values():
                     service.version = version

--- a/src/spacel/cli/secret.py
+++ b/src/spacel/cli/secret.py
@@ -19,8 +19,9 @@ def secret_cmd():  # pragma: no cover
 
 @secret_cmd.command(help='Encrypt secrets.')
 @click.option('--orbit', type=click.STRING, help='Orbit name/path.',
-              required=True)
-@click.option('--app', type=click.STRING, help='App name/path.', required=True)
+              envvar='SPACEL_ORBIT', required=True)
+@click.option('--app', type=click.STRING, help='App name/path.',
+              envvar='SPACEL_APP', required=True, default='/pwd')
 @click.option('--region', '-r', multiple=True, type=click.Choice(VALID_REGIONS),
               help='Regions to encrypt secret in.')
 @click.option('--create', '--create-key', is_flag=True,
@@ -29,8 +30,8 @@ def secret_cmd():  # pragma: no cover
               help='Write secrets directly to file.')
 @click.option('--key', type=click.STRING, help='Environment variable key.')
 @click.option('--value', type=click.STRING, help='Secret value')
-@click.option('--log-level', default='WARNING', type=click.Choice(LOG_LEVELS),
-              help='Log level')
+@click.option('--log-level', default='INFO', type=click.Choice(LOG_LEVELS),
+              envvar='SPACEL_LOG_LEVEL', help='Log level')
 def secret(orbit, app, region, create_key, modify, key, value,
            log_level):  # pragma: no cover
     handle_secret(orbit, app, region, create_key, modify, key, value, log_level,

--- a/src/spacel/main.py
+++ b/src/spacel/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import logging
-import sys
 
 from colorlog import ColoredFormatter
 
@@ -41,18 +40,7 @@ def setup_logging(level=logging.DEBUG):
     logging.getLogger('spacel').setLevel(logging.DEBUG)
 
 
-def legacy_args(args):
-    # Legacy support: map 2 simple args to `provision` subcommand
-    if len(args) == 2:
-        no_dash = [arg for arg in args if not arg.startswith('--')]
-        if len(no_dash) == 2:
-            args.insert(0, 'provision')
-            args.insert(1, '--orbit')
-            args.insert(3, '--app')
-
-
 if __name__ == '__main__':  # pragma: no cover
     from spacel.cli import cli
 
-    legacy_args(sys.argv)
-    cli()
+    cli(prog_name='spacel')

--- a/src/test/test_main.py
+++ b/src/test/test_main.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 
-from spacel.main import setup_logging, legacy_args
+from spacel.main import setup_logging
 
 
 class TestMain(unittest.TestCase):
@@ -23,13 +23,3 @@ class TestMain(unittest.TestCase):
         setup_logging(logging.DEBUG)
         stream_handler = self.root_logger.handlers[0]
         self.assertEquals(logging.DEBUG, stream_handler.level)
-
-    def test_main_passthrough(self):
-        args = ['provision', '--orbit', 'foo', '--app', 'bar']
-        legacy_args(args)
-        self.assertEquals(['provision', '--orbit', 'foo', '--app', 'bar'], args)
-
-    def test_main_legacy(self):
-        args = ['foo', 'bar']
-        legacy_args(args)
-        self.assertEquals(['provision', '--orbit', 'foo', '--app', 'bar'], args)


### PR DESCRIPTION
Tiny bit of bash makes running `spacel-provision` from docker a little
friendlier.

Removed legacy_args handling as it messed with bash completion:
call it <1.0 freedom.

Removed said bash completion WIP because it was god-awful slow.