### PR TITLE
`spacel provision --force`

### DIFF
--- a/src/spacel/cli/provision.py
+++ b/src/spacel/cli/provision.py
@@ -61,17 +61,18 @@ def provision_cmd():  # pragma: no cover
 @click.option('--log-level', default='INFO', type=click.Choice(LOG_LEVELS),
               envvar='SPACEL_LOG_LEVEL', help='Log level')
 @click.option('--version', type=click.STRING, help='Version to deploy')
+@click.option('--force', is_flag=True, help='Force redeploy.')
 def provision_cli(orbit, app, region, lambda_bucket, lambda_region,
                   template_bucket, template_region, pagerduty_default,
                   pagerduty_api_key, spacel_agent_channel,
                   spacel_agent_cache_bust, log_level,
-                  version):  # pragma: no cover
+                  version, force):  # pragma: no cover
     provision_services(orbit, app, region,
                        lambda_bucket, lambda_region,
                        template_bucket, template_region,
                        pagerduty_default, pagerduty_api_key,
                        spacel_agent_channel, spacel_agent_cache_bust,
-                       log_level, version)
+                       log_level, version, force)
 
 
 def provision_services(orbit_path, app_path, regions,
@@ -79,7 +80,7 @@ def provision_services(orbit_path, app_path, regions,
                        template_bucket, template_region,
                        pagerduty_default, pagerduty_api_key,
                        spacel_agent_channel, spacel_agent_cache_bust,
-                       log_level, version):
+                       log_level, version, force_redeploy):
     helper = ClickHelper()
     helper.setup_logging(log_level)
 
@@ -95,7 +96,8 @@ def provision_services(orbit_path, app_path, regions,
 
     return provision(app, lambda_bucket, lambda_region, template_bucket,
                      template_region, pagerduty_default, pagerduty_api_key,
-                     spacel_agent_channel, spacel_agent_cache_bust)
+                     spacel_agent_channel, spacel_agent_cache_bust,
+                     force_redeploy)
 
 
 def provision(app,
@@ -106,7 +108,8 @@ def provision(app,
               pagerduty_default=None,
               pagerduty_api_key=None,
               spacel_agent_channel=None,
-              spacel_agent_cache_bust=False):  # pragma: no cover
+              spacel_agent_cache_bust=False,
+              force_redeploy=False):  # pragma: no cover
     clients = ClientCache()
 
     # Lambda function storage
@@ -144,6 +147,6 @@ def provision(app,
     orbit_factory.orbit(app.orbit)
     provisioner = SpaceElevatorAppFactory(clients, change_sets, template_up,
                                           app_template)
-    if not provisioner.app(app):
+    if not provisioner.app(app, force_redeploy=force_redeploy):
         return 1
     return 0

--- a/src/spacel/cloudformation/elb-service.template
+++ b/src/spacel/cloudformation/elb-service.template
@@ -103,6 +103,11 @@
       "Description": "Private RDS subnet group",
       "Type": "String",
       "Default": ""
+    },
+    "UniqueToken": {
+      "Description": "Unique token. Provide a new value to force ASG redeploy.",
+      "Type": "String",
+      "Default": ""
     }
   },
   "Conditions": {
@@ -577,7 +582,10 @@
                 {"Ref": "DeployLogGroup"},
                 "\",",
                 "\"level\":\"DEBUG\"",
-                "}}",
+                "}},",
+                "\"unique_token\":\"",
+                {"Ref": "UniqueToken"},
+                "\"",
                 {"Ref": "UserData"},
                 "}"
               ]

--- a/src/spacel/provision/app/space.py
+++ b/src/spacel/provision/app/space.py
@@ -1,4 +1,6 @@
 import logging
+import uuid
+
 
 from spacel.provision.cloudformation import BaseCloudFormationFactory
 
@@ -11,21 +13,34 @@ class SpaceElevatorAppFactory(BaseCloudFormationFactory):
                                                       uploader)
         self._app_template = app_template
 
-    def app(self, app):
+    def app(self, app, force_redeploy=False):
         """
         Provision an app in all regions.
         :param app:  App to provision.
+        :param force_redeploy: Force redeploying this application.
         :returns True if updates completed.
         """
         app_name = app.full_name
         updates = {}
+        unique_token = str(uuid.uuid4())
+
+        params = {}
+        if force_redeploy:
+            # New token: force redeploy according to UpdatePolicy
+            params['UniqueToken'] = unique_token
+
         for region, app_region in app.regions.items():
             template, secret_params = self._app_template.app(app_region)
             if not template and not secret_params:
-                logger.warn('App %s will not be updated, invalid syntax!',
-                            app_name)
+                logger.warning('App %s will not be updated, invalid syntax!',
+                               app_name)
                 continue
+
+            secret_params = secret_params or {}
+            # Treat token as a secret: re-use existing value if possible.
+            secret_params['UniqueToken'] = lambda: unique_token
             updates[region] = self._stack(app_name, region, template,
+                                          parameters=params,
                                           secret_parameters=secret_params)
         return self._wait_for_updates(app_name, updates)
 

--- a/src/test/cli/test_provision.py
+++ b/src/test/cli/test_provision.py
@@ -17,7 +17,7 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL', None)
+                           None, None, None, None, 'CRITICAL', None, False)
         mock_provision.assert_not_called()
 
     @patch('spacel.cli.provision.ClickHelper')
@@ -32,7 +32,7 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL', None)
+                           None, None, None, None, 'CRITICAL', None, False)
         mock_provision.assert_not_called()
 
     @patch('spacel.cli.provision.ClickHelper')
@@ -44,6 +44,6 @@ class TestProvisionCommand(BaseSpaceAppTest):
         helper_factory.return_value = helper
 
         provision_services(ORBIT_NAME, APP_NAME, (), None, None, None, None,
-                           None, None, None, None, 'CRITICAL', None)
+                           None, None, None, None, 'CRITICAL', None, False)
         mock_provision.assert_called_once_with(ANY, None, None, None, None,
-                                               None, None, None, None)
+                                               None, None, None, None, False)

--- a/src/test/provision/app/test_space.py
+++ b/src/test/provision/app/test_space.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from mock import MagicMock, ANY
 
 from spacel.aws import ClientCache
 from spacel.model import OrbitRegion, SpaceAppRegion
@@ -38,6 +38,16 @@ class TestSpaceElevatorAppFactory(BaseSpaceAppTest):
 
         self.assertEquals(2, self.provisioner._stack.call_count)
         self.assertEquals(1, self.provisioner._wait_for_updates.call_count)
+
+    def test_app_redeploy(self):
+        self.provisioner._stack.return_value = 'create'
+
+        self.provisioner.app(self.app, force_redeploy=True)
+
+        self.provisioner._stack.assert_called_with(ANY, ANY, ANY,
+                                                   parameters={
+                                                       'UniqueToken': ANY
+                                                   }, secret_parameters=ANY)
 
     def test_app_delete(self):
         self.provisioner._stack.return_value = 'delete'


### PR DESCRIPTION
Sometimes you just don't trust the instances you're running on, and want
new ones. Make that possible without requiring manifest-level NOOPs.

Fixes #66