### PR TITLE
botocore bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.4.0
-botocore==1.4.51
+boto3==1.4.3
+botocore==1.4.91
 click==6.6
 colorlog==2.7.0
 docutils==0.12


### PR DESCRIPTION
This is required for `python-3.6`:
https://github.com/boto/botocore/issues/1079

Blame homebrew for making upgrading _too_ easy!